### PR TITLE
Fix trap host issue

### DIFF
--- a/deploy/sc4snmp/traps-deployment.yaml
+++ b/deploy/sc4snmp/traps-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: traps
-          image: ghcr.io/splunk/splunk-connect-for-snmp-traps:v0.4.0-develop.2
+          image: ghcr.io/splunk/splunk-connect-for-snmp-traps:50a01ab7e27ab1ce4ac8690322f50e8339cfc911
           args: ["--loglevel=DEBUG", "--config=/work/config/config.yaml", "--index=snmp"]
           ports:
             - containerPort: 2162

--- a/deploy/sc4snmp/traps-service.yaml
+++ b/deploy/sc4snmp/traps-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: sc4-snmp-traps
 spec:
+  externalTrafficPolicy: Local
   type: LoadBalancer
   # loadBalancerIP: replace-me
   ports:


### PR DESCRIPTION
Raise this PR to close #34 
- Set the host to be the trap sender's IP address instead of the trap sender's hostname
- Resolve the cluster network issue to get the correct sender's IP address instead of the masking IP when sending traps from external machines.
