### PR TITLE
fix (doc): broken tags in documentation

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -108,18 +108,18 @@ Setup Poller
 Agents configuration is placed in scheduler-config.yaml under section inventory.csv, content below is interpreted as csv file
 with following columns:
 
-*. host (IP or name)
-*. version of SNMP protocol
-*. community string authorisation phrase
-*. profile of device (varBinds of profiles can be found in convig.yaml section of scheduler-config.yaml file)
-*. frequency in seconds (how often SNMP connector should ask agent for data)
+1. host (IP or name)
+2. version of SNMP protocol
+3. community string authorisation phrase
+4. profile of device (varBinds of profiles can be found in convig.yaml section of scheduler-config.yaml file)
+5. frequency in seconds (how often SNMP connector should ask agent for data)
 
 .. code-block:: bash
+
     cp deploy/sc4snmp/ftr/scheduler-inventory.yaml ~/scheduler-inventory.yaml
     vi ~/scheduler-inventory.yaml
     # Remove the comment from line 2 and correct the ip and community value
     kubectl apply -n sc4snmp -f ~/scheduler-inventory.yaml
-
 
 Test Poller
 ===================================================


### PR DESCRIPTION
- when using *. as a bullet list, for some reason the code-block
  disappeared. Now it is visible again