### PR TITLE
enhance object collection code readability

### DIFF
--- a/deploy/sc4snmp/sck.yaml
+++ b/deploy/sc4snmp/sck.yaml
@@ -78,7 +78,13 @@ spec:
       objects:
         core:
           v1:
-            [{ "name": "pods", "interval": "300s" },{ "name": "nodes", "interval": "300s" },{ "name": "component_statuses", "interval": "300s" },{ "name": "namespaces", "interval": "300s" },{ "name": "services", "interval": "300s" },{ "name": "events", "mode": "watch" }]
+            - name: pods
+            - name: namespaces
+            - name: component_statuses
+            - name: nodes
+            - name: services
+            - name: events
+              mode: watch
       splunk:
         hec:
           indexName: ##META_INDEX##

--- a/deploy/sck/sck_147.yaml
+++ b/deploy/sck/sck_147.yaml
@@ -75,7 +75,13 @@ splunk-kubernetes-objects:
   objects:
     core:
       v1:
-        [{ "name": "pods", "interval": "300s" },{ "name": "nodes", "interval": "300s" },{ "name": "component_statuses", "interval": "300s" },{ "name": "namespaces", "interval": "300s" },{ "name": "services", "interval": "300s" },{ "name": "events", "mode": "watch" }]
+        - name: pods
+        - name: namespaces
+        - name: component_statuses
+        - name: nodes
+        - name: services
+        - name: events
+          mode: watch
   splunk:
     hec:
       indexName: ##META_INDEX##


### PR DESCRIPTION
As requested in https://github.com/splunk/splunk-connect-for-snmp/pull/75 updated yaml to use yaml list to make code easier to read. 

I have chosen to keep it as simple as it gets and accept the default polling of 15m. Full options list for objects is here, incase we want to iterate. There is namespace scoping but it looks like you need to define an input per type per namespace, so i skipped for now while I check with @rockb1017 

https://github.com/splunk/splunk-connect-for-kubernetes/blob/eab9ab19617fcd153e47aac417c80727f7edf0e7/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml#L76-L118

Tests:

Deployed from main, then used this branch to delete and redeploy sck helmrelease with objects enabled and with yaml list version of config. Here is the result on cli and in splunk:

```
root@ip-10-202-35-134:/home/splunker/splunk-connect-for-snmp/deploy/sc4snmp# microk8s.kubectl -n sck get pods
NAME                                                 READY   STATUS    RESTARTS   AGE
sck-sck-splunk-kubernetes-logging-wnnxc              1/1     Running   0          14m
sck-sck-splunk-kubernetes-objects-6f8d89b76b-hshdw   1/1     Running   0          14m
```

![image](https://user-images.githubusercontent.com/31549209/118146846-018b9000-b3dd-11eb-9a21-7088ac5e4962.png)


How the configmap will render:

```
root@ip-10-202-35-134:/home/splunker/splunk-connect-for-snmp/deploy/sc4snmp# microk8s.kubectl -n sck get cm sck-sck-splunk-kubernetes-objects -o yaml
apiVersion: v1
data:
  fluent.conf: |
    <system>
      log_level info
    </system>
    <source>
      @type kubernetes_objects
      tag kube.objects.*
      api_version "v1"
      insecure_ssl true
      <pull>
        resource_name pods
      </pull>
      <pull>
        resource_name namespaces
      </pull>
      <pull>
        resource_name component_statuses
      </pull>
      <pull>
        resource_name nodes
      </pull>
      <pull>
        resource_name services
      </pull>
      <watch>
        resource_name events
      </watch>
    </source>

    <filter kube.**>
      @type jq_transformer
      # in ruby '\\' will escape and become just '\', since we need two '\' in the `gsub` jq filter, it becomes '\\\\'.
      jq '.record.source = "namespace:\(env.MY_NAMESPACE)/pod:\(env.MY_POD_NAME)" | .record.sourcetype = (.tag | gsub("\\\\."; ":")) | .record'
    </filter>

    <filter kube.**>
      @type jq_transformer
      jq '.record.cluster_name = "mattymo-objects-config-cleanup" | .record'
    </filter>

    # = custom filters specified by users =

    <match kube.**>
      @type splunk_hec
      protocol https
      hec_host "my host"
      hec_port 8088
      hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
      host "#{ENV['NODE_NAME']}"
      source_key source
      sourcetype_key sourcetype
      index snmp_meta
      insecure_ssl true
      <fields>
        cluster_name
      </fields>
      app_name splunk-kubernetes-objects
      app_version 1.4.7
      <buffer>
        @type memory
        chunk_limit_records 10000
        chunk_limit_size 20m
        flush_interval 5s
        flush_thread_count 1
        overflow_action block
        retry_max_times 5
        retry_type periodic
        total_limit_size 600m
      </buffer>
    </match>
kind: ConfigMap
metadata:
  annotations:
    helm.fluxcd.io/antecedent: sck:helmrelease/sck
  creationTimestamp: "2021-05-13T15:02:22Z"
  labels:
    app: splunk-kubernetes-objects
    chart: splunk-kubernetes-objects-1.4.7
    heritage: Helm
    release: sck-sck
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:data:
        .: {}
        f:fluent.conf: {}
      f:metadata:
        f:labels:
          .: {}
          f:app: {}
          f:chart: {}
          f:heritage: {}
          f:release: {}
    manager: Go-http-client
    operation: Update
    time: "2021-05-13T15:02:22Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:helm.fluxcd.io/antecedent: {}
    manager: kubectl
    operation: Update
    time: "2021-05-13T15:02:22Z"
  name: sck-sck-splunk-kubernetes-objects
  namespace: sck
  resourceVersion: "5559"
  selfLink: /api/v1/namespaces/sck/configmaps/sck-sck-splunk-kubernetes-objects
  uid: 83125c6b-2316-4024-91ef-36e90f1fda70
```
