### PR TITLE
helm: change readOnly permissions from inventory to false

### DIFF
--- a/deploy-helm/snmp-installer/templates/sc4snmp/internal/scheduler-deployment.yaml
+++ b/deploy-helm/snmp-installer/templates/sc4snmp/internal/scheduler-deployment.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
             - name: inventory
               mountPath: "/work/inventory"
-              readOnly: true
+              readOnly: false
           resources:
 {{ toYaml .Values.mib.resources | indent 12 }}
       volumes:


### PR DESCRIPTION
Changing readOnly permissions from inventory to false because of refresh function we have in poller.
This is the fix for this error:
```

2021-10-12 09:17:16,139 | schedule | DEBUG | Running job Job(interval=2, unit=minutes, do=refresh_inventory, args=('/work/inventory/inventory.csv',), kwargs={})
Traceback (most recent call last):
  File "/usr/local/bin/sc4snmp-poller", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/snmp_poller_server.py", line 34, in main
    poller_server.run()
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/manager/poller.py", line 75, in run
    schedule.run_pending()
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 780, in run_pending
    default_scheduler.run_pending()
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 100, in run_pending
    self._run_job(job)
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 172, in _run_job
    ret = job.run()
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 661, in run
    ret = self.job_func()
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/manager/poller_utilities.py", line 66, in refresh_inventory
    Path(inventory_file_path).touch()
  File "/usr/lib64/python3.8/pathlib.py", line 1277, in touch
    fd = self._raw_open(flags, mode)
  File "/usr/lib64/python3.8/pathlib.py", line 1086, in _raw_open
    return self._accessor.open(self, flags, mode)
OSError: [Errno 30] Read-only file system: '/work/inventory/inventory.csv'
```