### PR TITLE
feat: Set worker replica's to two by default

### DIFF
--- a/charts/templates/poller/scheduler-deployment.yaml
+++ b/charts/templates/poller/scheduler-deployment.yaml
@@ -23,8 +23,8 @@ spec:
           fsGroup: 2000    
       containers:
         - name: sc4snmp-scheduler
-          image: {{ .Values.worker.image | default "ghcr.io/splunk/splunk-connect-for-snmp-poller/container" }}:{{ .Values.worker.tag | default "1" }}
-          imagePullPolicy: {{ .Values.worker.pullPolicy | default "IfNotPresent" }}
+          image: {{ .Values.poller.image | default "ghcr.io/splunk/splunk-connect-for-snmp-poller/container" }}:{{ .Values.poller.tag | default "1" }}
+          imagePullPolicy: {{ .Values.poller.pullPolicy | default "IfNotPresent" }}
           args:
             [
               {{ printf "\"--log=%s\"" ( .Values.scheduler.logLevel | default "WARN" ) }},

--- a/charts/templates/poller/worker-deployment.yaml
+++ b/charts/templates/poller/worker-deployment.yaml
@@ -22,8 +22,8 @@ spec:
           fsGroup: 2000
       containers:
         - name: sc4snmp-worker
-          image: {{ .Values.worker.image | default "ghcr.io/splunk/splunk-connect-for-snmp-poller/container" }}:{{ .Values.worker.tag | default "1" }}
-          imagePullPolicy: {{ .Values.worker.pullPolicy | default "IfNotPresent" }}
+          image: {{ .Values.poller.image | default "ghcr.io/splunk/splunk-connect-for-snmp-poller/container" }}:{{ .Values.poller.tag | default "1" }}
+          imagePullPolicy: {{ .Values.poller.pullPolicy | default "IfNotPresent" }}
           args: [{{ printf "\"--log=%s\"" ( .Values.worker.logLevel | default "WARN" ) }}, "--config=/work/config/config.yaml"]
           securityContext:
             allowPrivilegeEscalation: false          

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -51,13 +51,14 @@ otel:
   signalfx_mode: "splunk"
   signalfx_token: ""
   signalfx_realm: ""
-worker:
+poller:
   image: ghcr.io/splunk/splunk-connect-for-snmp-poller/container
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "1"
+worker:
   #  logLevel: "WARN"
-  replicas: 1
+  replicas: 2
 #  resources:
 #    limits:
 #      cpu: 200m

--- a/charts/values.yaml.example
+++ b/charts/values.yaml.example
@@ -5,6 +5,15 @@ splunk:
   insecureSSL: "false"
   port: ###SPLUNK_PORT###
   clusterName: ###CLUSTER_NAME###
+otel:
+  image: quay.io/signalfx/splunk-otel-collector
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.22.0"
+  replicas: 1
+  signalfx_mode: "splunk"
+  signalfx_token: ""
+  signalfx_realm: ""
 traps:
   image: ghcr.io/splunk/splunk-connect-for-snmp-traps/container
   pullPolicy: IfNotPresent
@@ -46,15 +55,6 @@ mib:
 #    requests:
 #      cpu: 100m
 #      memory: 128Mi
-otel:
-  image: quay.io/signalfx/splunk-otel-collector
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.22.0"
-  replicas: 1
-  signalfx_mode: "splunk"
-  signalfx_token: ""
-  signalfx_realm: ""
 worker:
   image: ghcr.io/splunk/splunk-connect-for-snmp-poller/container
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Workers should be HA by default. Depends on PR https://github.com/splunk/splunk-connect-for-snmp-poller/pull/190
Moved the image info from worker to "poller" as this is shared between poller and scheduler and both must be the same