### PR TITLE
fix: update config.yaml to config.yaml.example

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,4 +1,5 @@
 poller:
+# this part has to be here for v2 pooling with community name public
   communities:
     public:
       communityIndex:
@@ -7,6 +8,7 @@ poller:
       tag:
       securityName:
     my-area:
+# this part has to be here for v3 pooling with community name snmp-poller
   usernames:
     simulator:
       authKey: "auctoritas"
@@ -14,13 +16,8 @@ poller:
     snmp-poller:
       authKey: PASSWORD1
       privKey: PASSWORD1
-      contextName: "4c9184f37cff01bcdc32dc486ec36961"
       authProtocol: SHA
       privProtocol: AES
-      securityEngineId: 8000000004030201
-      securityName:
-      authKeyType: 0
-      privKeyType: 0
   profiles:
     BaseUpTime:
       frequency: 60


### PR DESCRIPTION
This PR removes config.yaml file, which is injected by Helm during the installation. 
In order to run SC4SNMP locally `config.yaml.example` must be renamed to `config.yaml`, and env variable:

```
export CONFIG_PATH=<absolute_path>/snmp/splunk-connect-for-snmp/splunk_connect_for_snmp/config.yaml
```
same for inventory:
```
export INVENTORY_PATH=<absolute_path>/snmp/splunk-connect-for-snmp/splunk_connect_for_snmp/inventory.csv
```