### PR TITLE
fix: delete full name for mongo and rabbitmq

### DIFF
--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -190,9 +190,6 @@ mongodb:
   ## @section Common parameters
   ##
 
-  ## @param fullnameOverride String to fully override mongodb.fullname template
-  ##
-  fullnameOverride: "sc4snmp-mongodb"
   ## @param clusterDomain Default Kubernetes cluster domain
   ##
   clusterDomain: cluster.local
@@ -249,13 +246,6 @@ rabbitmq:
   podManagementPolicy: Parallel
   ## @section Common parameters
 
-  ## @param nameOverride String to partially override rabbitmq.fullname template (will maintain the release name)
-  ##
-  nameOverride: "sc4snmp-rabbitmq"
-
-  ## @param fullnameOverride String to fully override rabbitmq.fullname template
-  ##
-  fullnameOverride: "sc4snmp-rabbitmq"
   rbac:
     create: true
   auth:


### PR DESCRIPTION
Fix an issue that cause:
```
Waiting for amqp://sc4snmp:*****@snmp-rabbitmq:5672/
Still waiting for amqp://sc4snmp:*****@snmp-rabbitmq:5672/ (20s elapsed)
Still waiting for amqp://sc4snmp:*****@snmp-rabbitmq:5672/ (40s elapsed)
Still waiting for amqp://sc4snmp:*****@snmp-rabbitmq:5672/ (60s elapsed)
Still waiting for amqp://sc4snmp:*****@snmp-rabbitmq:5672/ (80s elapsed)
Still waiting for amqp://sc4snmp:*****@snmp-rabbitmq:5672/ (100s elapsed)
```