### PR TITLE
fix: delete rebase from mike

### DIFF
--- a/.github/workflows/cd-pages.yaml
+++ b/.github/workflows/cd-pages.yaml
@@ -66,7 +66,7 @@ jobs:
           if [[ $VERSION != *"develop"* ]]; then
             pip3 install poetry
             poetry install
-            poetry run mike deploy --rebase -p $VERSION
+            poetry run mike deploy -p $VERSION
           fi
   helm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This can be the fix for:
```
error: failed to push some refs to 'https://github.com/splunk/splunk-connect-for-snmp'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details."
```

according to https://github.com/jimporter/mike/issues/60