### PR TITLE
fix: change retries for walk

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 . /app/.venv/bin/activate
 LOG_LEVEL=${LOG_LEVEL:=INFO}
-WORKER_CONCURRENCY=${WORKER_CONCURRENCY:=2}
+WORKER_CONCURRENCY=${WORKER_CONCURRENCY:=4}
 wait-for-dep "${CELERY_BROKER_URL}" "${MONGO_URI}" "${MIB_INDEX}"
 
 case $1 in

--- a/splunk_connect_for_snmp/snmp/tasks.py
+++ b/splunk_connect_for_snmp/snmp/tasks.py
@@ -56,9 +56,10 @@ CONFIG_PATH = os.getenv("CONFIG_PATH", "/app/config/config.yaml")
 @shared_task(
     bind=True,
     base=Poller,
-    retry_backoff=True,
+    retry_backoff=30,
     retry_jitter=True,
     retry_backoff_max=3600,
+    max_retries=50,
     autoretry_for=(MongoLockLocked, SnmpActionError,),
     throws=(SnmpActionError, SnmpActionError,)
 )


### PR DESCRIPTION
Turns out we need to have `max_retries` parameter in celery task, `retry_backoff_max` doesn't stop the tasks