### PR TITLE
fix: only lock one item per thread

### DIFF
--- a/splunk_connect_for_snmp/celery_config.py
+++ b/splunk_connect_for_snmp/celery_config.py
@@ -18,6 +18,7 @@ from contextlib import suppress
 
 with suppress(ImportError):
     from dotenv import load_dotenv
+
     load_dotenv()
 
 
@@ -39,3 +40,8 @@ mongodb_backend_settings = {"database": MONGO_DB_CELERY_DATABASE}
 beat_scheduler = "celerybeatmongo.schedulers.MongoScheduler"
 mongodb_scheduler_url = MONGO_URI
 mongodb_scheduler_db = MONGO_DB_CELERY_DATABASE
+
+# Optimization for long running tasks
+# https://docs.celeryproject.org/en/stable/userguide/optimizing.html#reserve-one-task-at-a-time
+task_acks_late = True
+worker_prefetch_multiplier = 1


### PR DESCRIPTION
For "long" tasks like snmp work celery recommends we only lock one task