### PR TITLE
feat: Load all standard mibs.

### DIFF
--- a/charts/splunk-connect-for-snmp/Chart.lock
+++ b/charts/splunk-connect-for-snmp/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 8.24.13
 - name: mibserver
   repository: https://pysnmp.github.io/mibs/charts/
-  version: 1.8.4
-digest: sha256:5eb0a97b13cf886ea4f19f3c6137c8907267266e0732cb0869d850bfaf84e763
-generated: "2022-01-15T21:12:33.542079-05:00"
+  version: 1.12.0
+digest: sha256:57c98330200019983930a73d12d21f627bbe8fde43d4a5ecb51b48165403326c
+generated: "2022-01-16T11:13:47.618842-05:00"

--- a/charts/splunk-connect-for-snmp/Chart.yaml
+++ b/charts/splunk-connect-for-snmp/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     version: ~8.24
     repository: https://charts.bitnami.com/bitnami
   - name: mibserver
-    version: ~1.8.1
+    version: ~1.12.0
     repository: https://pysnmp.github.io/mibs/charts/
 #    condition: (optional) A yaml path that resolves to a boolean, used for enabling/disabling charts (e.g. subchart1.enabled )
 #    tags: # (optional)

--- a/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -39,6 +39,8 @@ spec:
             value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/asn1/@mib@"
           - name: MIB_INDEX
             value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/index.csv"
+          - name: MIB_STANDARD
+            value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/standard.txt"
           - name: LOG_LEVEL
             value: {{ .Values.scheduler.logLevel | default "INFO" }}
           volumeMounts:

--- a/charts/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/asn1/@mib@"
             - name: MIB_INDEX
               value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/index.csv"
+            - name: MIB_STANDARD
+              value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/standard.txt"
             - name: LOG_LEVEL
               value: {{ .Values.scheduler.logLevel | default "INFO" }}
             - name: INVENTORY_REFRESH_RATE

--- a/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/asn1/@mib@"
             - name: MIB_INDEX
               value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/index.csv"
+            - name: MIB_STANDARD
+              value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/standard.txt"
             - name: LOG_LEVEL
               value: {{ .Values.traps.logLevel | default "INFO" }}
 {{- if .Values.splunk.protocol }}

--- a/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/asn1/@mib@"
             - name: MIB_INDEX
               value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/index.csv"
+            - name: MIB_STANDARD
+              value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/standard.txt"
             {{- if .Values.splunk.enabled }}
             {{- if .Values.splunk.protocol }}
             - name: SPLUNK_HEC_SCHEME

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -212,6 +212,7 @@ class Poller(Task):
         self.builder = None
         self.mib_view_controller = None
         self.mib_map = None
+        self.standard_mibs = []
 
     def initialize(self):
 
@@ -242,9 +243,11 @@ class Poller(Task):
                 while mib:
                     if mib.strip() != "":
                         self.builder.loadModules(mib)
+                        self.standard_mibs.append(mib)
                     mib = standard_raw.readline()
         else:
             for mib in DEFAULT_STANDARD_MIBS:
+                self.standard_mibs.append(mib)
                 self.builder.loadModules(mib)
 
         mib_response = self.session.get(f"{MIB_INDEX}")

--- a/splunk_connect_for_snmp/snmp/tasks.py
+++ b/splunk_connect_for_snmp/snmp/tasks.py
@@ -38,8 +38,6 @@ from splunk_connect_for_snmp.snmp.manager import Poller
 
 logger = get_task_logger(__name__)
 
-MIB_SOURCES = os.getenv("MIB_SOURCES", "https://pysnmp.github.io/mibs/asn1/@mib@")
-MIB_INDEX = os.getenv("MIB_INDEX", "https://pysnmp.github.io/mibs/index.csv")
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 CONFIG_PATH = os.getenv("CONFIG_PATH", "/app/config/config.yaml")


### PR DESCRIPTION
Using a new list provided by the mib library when a worker starts up re-load all standard mibs. While not all standard mibs will be required this should save a non-trival amount of time in the discovery phase.