### PR TITLE
fix: repeat process_snmp_data right after loading mibs

### DIFF
--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -310,8 +310,9 @@ class Poller(Task):
                     )
                     if tmp_mibs:
                         self.load_mibs(tmp_mibs)
-                    if tmp_retry:
-                        retry = True
+                        self.process_snmp_data(
+                            varBindTable, metrics, address, bulk_mapping
+                        )
 
         if varbinds_get:
             for (errorIndication, errorStatus, errorIndex, varBindTable,) in getCmd(


### PR DESCRIPTION
# Description

This change decrease walk time by 2 times. Instead of using retry variable after loading all of the missing mibs and going through all of the walk OIDs again, we repeat process_snmp_data right after loading mibs.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I ran it locally against 1.3.6.1.2.1 OID. Before the change walk took 20 minutes, after the change it was decreased to 10 minutes.

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings