### PR TITLE
fix: exclude empty string from remotemibs

### DIFF
--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -491,7 +491,7 @@ class Poller(Task):
                     )
             else:
                 found, mib = self.is_mib_known(id, oid, target)
-                if mib not in remotemibs:
+                if mib and mib not in remotemibs:
                     remotemibs.append(mib)
                 if found:
                     retry = True


### PR DESCRIPTION
# Description

Fix problem with empty string comparision. Because of previously added pre-commit, when all mibs are loaded, from self.is_mib_konwn "" is sometimes returned and breaks if condition:
```
if mib and mib not in remotemibs:
    remotemibs.append(mib)
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests and tested locally

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings