### PR TITLE
fix: add ignoring increasing oids error for certain hosts

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
@@ -46,6 +46,10 @@ spec:
               value: {{ include "splunk-connect-for-snmp.celery_url" . }}
             - name: MONGO_URI
               value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
+            {{- if .Values.worker.ignoreNotIncreasingOid }}
+            - name: IGNORE_NOT_INCREASING_OIDS
+              value: {{ join "," .Values.worker.ignoreNotIncreasingOid }}
+            {{- end}}
             {{- if .Values.sim.enabled }}
             - name: OTEL_METRICS_URL
               value: "http://{{ .Release.Name }}-{{ include "splunk-connect-for-snmp.name" . }}-sim:8882"

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -94,6 +94,7 @@ scheduler:
   podAntiAffinity: soft
 
 worker:
+  ignoreNotIncreasingOid: []
   replicaCount: 2
   concurrency: 4
   nameOverride: ""

--- a/docs/bestpractices.md
+++ b/docs/bestpractices.md
@@ -29,7 +29,7 @@ In case you see the following line in worker's logs:
 ```
 that causes infinite retry of walk operation, add `worker.ignoreEmptyVarbinds` parameter to `values.yaml` and set it to true.
 
-An example confiuration for worker in `values.yaml` is:
+An example configuration for worker in `values.yaml` is:
 
 ```yaml
 worker:
@@ -44,7 +44,7 @@ In case you see the following line in worker's logs:
 ```
 that causes infinite retry of walk operation, add `worker.ignoreNotIncreasingOid` array to `values.yaml` and fill with the addresses of hosts where the problem appears.
 
-An example confiuration for worker in `values.yaml` is:
+An example configuration for worker in `values.yaml` is:
 
 ```yaml
 worker:
@@ -54,4 +54,4 @@ worker:
 ```
 
 If you put only ip address (ex. `127.0.0.1`), then errors will be ignored for all of its devices (like `127.0.0.1:161`, 
-`127.0.0.1:163`...). If you put ip address and host structured as: `{host}:{port` that means the error will be ignored only for this device.
+`127.0.0.1:163`...). If you put ip address and host structured as: `{host}:{port}` that means the error will be ignored only for this device.

--- a/docs/bestpractices.md
+++ b/docs/bestpractices.md
@@ -35,3 +35,23 @@ An example confiuration for worker in `values.yaml` is:
 worker:
   ignoreEmptyVarbinds: true
 ```
+
+### "OID not increasing" problem
+In case you see the following line in worker's logs:
+
+```log
+[2022-01-04 11:44:22,553: INFO/ForkPoolWorker-1] Task splunk_connect_for_snmp.snmp.tasks.walk[8e62fc62-569c-473f-a765-ff92577774e5] retry: Retry in 3489s: SnmpActionError('An error of SNMP isWalk=True for a host 192.168.10.20 occurred: OID not increasing')
+```
+that causes infinite retry of walk operation, add `worker.ignoreNotIncreasingOid` array to `values.yaml` and fill with the addresses of hosts where the problem appears.
+
+An example confiuration for worker in `values.yaml` is:
+
+```yaml
+worker:
+  ignoreNotIncreasingOid:
+    - "127.0.0.1:164"
+    - "127.0.0.6"
+```
+
+If you put only ip address (ex. `127.0.0.1`), then errors will be ignored for all of its devices (like `127.0.0.1:161`, 
+`127.0.0.1:163`...). If you put ip address and host structured as: `{host}:{port` that means the error will be ignored only for this device.

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -51,6 +51,7 @@ from splunk_connect_for_snmp.snmp.exceptions import SnmpActionError
 MIB_SOURCES = os.getenv("MIB_SOURCES", "https://pysnmp.github.io/mibs/asn1/@mib@")
 MIB_INDEX = os.getenv("MIB_INDEX", "https://pysnmp.github.io/mibs/index.csv")
 MIB_STANDARD = os.getenv("MIB_STANDARD", "https://pysnmp.github.io/mibs/standard.txt")
+HOSTS_TO_IGNORE_NOT_INCREASING_OIDS = os.getenv("IGNORE_NOT_INCREASING_OIDS", "").split(",")
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 IGNORE_EMPTY_VARBINDS = human_bool(os.getenv("IGNORE_EMPTY_VARBINDS", False))
@@ -75,6 +76,12 @@ def return_address_and_port(target):
         return address_tuple[0], int(address_tuple[1])
     else:
         return target, 161
+
+
+def is_increasing_oids_ignored(host, port):
+    if host in HOSTS_TO_IGNORE_NOT_INCREASING_OIDS or f"{host}:{port}" in HOSTS_TO_IGNORE_NOT_INCREASING_OIDS:
+        return True
+    return False
 
 
 def get_inventory(mongo_inventory, address):
@@ -296,6 +303,7 @@ class Poller(Task):
                 10,
                 *varbinds_bulk,
                 lexicographicMode=False,
+                ignoreNonIncreasingOid=is_increasing_oids_ignored(ir.address, ir.port),
             ):
                 if not _any_failure_happened(
                     errorIndication,

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -51,7 +51,9 @@ from splunk_connect_for_snmp.snmp.exceptions import SnmpActionError
 MIB_SOURCES = os.getenv("MIB_SOURCES", "https://pysnmp.github.io/mibs/asn1/@mib@")
 MIB_INDEX = os.getenv("MIB_INDEX", "https://pysnmp.github.io/mibs/index.csv")
 MIB_STANDARD = os.getenv("MIB_STANDARD", "https://pysnmp.github.io/mibs/standard.txt")
-HOSTS_TO_IGNORE_NOT_INCREASING_OIDS = os.getenv("IGNORE_NOT_INCREASING_OIDS", "").split(",")
+HOSTS_TO_IGNORE_NOT_INCREASING_OIDS = os.getenv("IGNORE_NOT_INCREASING_OIDS", "").split(
+    ","
+)
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 IGNORE_EMPTY_VARBINDS = human_bool(os.getenv("IGNORE_EMPTY_VARBINDS", False))
@@ -79,7 +81,10 @@ def return_address_and_port(target):
 
 
 def is_increasing_oids_ignored(host, port):
-    if host in HOSTS_TO_IGNORE_NOT_INCREASING_OIDS or f"{host}:{port}" in HOSTS_TO_IGNORE_NOT_INCREASING_OIDS:
+    if (
+        host in HOSTS_TO_IGNORE_NOT_INCREASING_OIDS
+        or f"{host}:{port}" in HOSTS_TO_IGNORE_NOT_INCREASING_OIDS
+    ):
         return True
     return False
 

--- a/test/snmp/test_utils.py
+++ b/test/snmp/test_utils.py
@@ -10,6 +10,7 @@ from splunk_connect_for_snmp.snmp.manager import (
     get_inventory,
     map_metric_type,
     return_address_and_port,
+    is_increasing_oids_ignored,
 )
 
 
@@ -144,3 +145,27 @@ class TestUtils(TestCase):
         self.assertEqual(return_address_and_port("127.0.0.1"), ("127.0.0.1", 161))
         self.assertEqual(return_address_and_port("168.99.9.9"), ("168.99.9.9", 161))
         self.assertEqual(return_address_and_port("168.99.9.9:162"), ("168.99.9.9", 162))
+
+    @mock.patch(
+        "splunk_connect_for_snmp.snmp.manager.HOSTS_TO_IGNORE_NOT_INCREASING_OIDS", ["127.0.0.1"]
+    )
+    def test_is_increasing_oids_ignored_only_host(self):
+        self.assertTrue(is_increasing_oids_ignored("127.0.0.1", "161"))
+        self.assertFalse(is_increasing_oids_ignored("127.0.0.2", "161"))
+        self.assertTrue(is_increasing_oids_ignored("127.0.0.1", "162"))
+
+    @mock.patch(
+        "splunk_connect_for_snmp.snmp.manager.HOSTS_TO_IGNORE_NOT_INCREASING_OIDS", ["127.0.0.1:162"]
+    )
+    def test_is_increasing_oids_ignored(self):
+        self.assertFalse(is_increasing_oids_ignored("127.0.0.1", "161"))
+        self.assertFalse(is_increasing_oids_ignored("127.0.0.2", "161"))
+        self.assertTrue(is_increasing_oids_ignored("127.0.0.1", "162"))
+
+    @mock.patch(
+        "splunk_connect_for_snmp.snmp.manager.HOSTS_TO_IGNORE_NOT_INCREASING_OIDS", []
+    )
+    def test_is_increasing_oids_ignored_empty(self):
+        self.assertFalse(is_increasing_oids_ignored("127.0.0.1", "161"))
+        self.assertFalse(is_increasing_oids_ignored("127.0.0.2", "161"))
+        self.assertFalse(is_increasing_oids_ignored("127.0.0.1", "162"))

--- a/test/snmp/test_utils.py
+++ b/test/snmp/test_utils.py
@@ -8,9 +8,9 @@ from splunk_connect_for_snmp.snmp.manager import (
     extract_index_number,
     fill_empty_value,
     get_inventory,
+    is_increasing_oids_ignored,
     map_metric_type,
     return_address_and_port,
-    is_increasing_oids_ignored,
 )
 
 
@@ -147,7 +147,8 @@ class TestUtils(TestCase):
         self.assertEqual(return_address_and_port("168.99.9.9:162"), ("168.99.9.9", 162))
 
     @mock.patch(
-        "splunk_connect_for_snmp.snmp.manager.HOSTS_TO_IGNORE_NOT_INCREASING_OIDS", ["127.0.0.1"]
+        "splunk_connect_for_snmp.snmp.manager.HOSTS_TO_IGNORE_NOT_INCREASING_OIDS",
+        ["127.0.0.1"],
     )
     def test_is_increasing_oids_ignored_only_host(self):
         self.assertTrue(is_increasing_oids_ignored("127.0.0.1", "161"))
@@ -155,7 +156,8 @@ class TestUtils(TestCase):
         self.assertTrue(is_increasing_oids_ignored("127.0.0.1", "162"))
 
     @mock.patch(
-        "splunk_connect_for_snmp.snmp.manager.HOSTS_TO_IGNORE_NOT_INCREASING_OIDS", ["127.0.0.1:162"]
+        "splunk_connect_for_snmp.snmp.manager.HOSTS_TO_IGNORE_NOT_INCREASING_OIDS",
+        ["127.0.0.1:162"],
     )
     def test_is_increasing_oids_ignored(self):
         self.assertFalse(is_increasing_oids_ignored("127.0.0.1", "161"))


### PR DESCRIPTION
# Description

This is a fix for an `OID not increasing` error returned from the SNMP device. This is being caused by wrong sequence of OIDs and is a problem on the device. This PR adds a way to ignore that problem via HELM configuration. 

Fixes # [(issue)](https://splunk.atlassian.net/browse/ADDON-47563)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I ran it locally and with Helm dry run. It will be tested on NOVA before merge with main.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings