### PR TITLE
fix: handle error during mib loading

### DIFF
--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -16,8 +16,8 @@
 import typing
 
 from pysnmp.proto.errind import EmptyResponse
-from requests import Session
 from pysnmp.smi import error
+from requests import Session
 
 from splunk_connect_for_snmp.inventory.loader import transform_address_to_key
 

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -17,6 +17,7 @@ import typing
 
 from pysnmp.proto.errind import EmptyResponse
 from requests import Session
+from pysnmp.smi import error
 
 from splunk_connect_for_snmp.inventory.loader import transform_address_to_key
 
@@ -353,7 +354,10 @@ class Poller(Task):
         logger.info(f"loading mib modules {mibs}")
         for mib in mibs:
             if mib:
-                self.builder.loadModules(mib)
+                try:
+                    self.builder.loadModules(mib)
+                except error.MibLoadError as e:
+                    logger.exception(f"Error loading mib for {mib}, e")
 
     def is_mib_known(self, id: str, oid: str, target: str) -> tuple[bool, str]:
 

--- a/test/snmp/test_mibs.py
+++ b/test/snmp/test_mibs.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock
+from pysnmp.smi import error
 
 from splunk_connect_for_snmp.snmp.manager import Poller, isMIBResolved
 
@@ -44,3 +45,10 @@ class TestMibProcessing(TestCase):
         self.assertFalse(isMIBResolved("SNMPv2-SMI::enterprises."))
         self.assertFalse(isMIBResolved("SNMPv2-SMI::mib-2"))
         self.assertTrue(isMIBResolved("OTHER"))
+
+    def test_exception_during_loading(self):
+        poller = Poller.__new__(Poller)
+        poller.builder = Mock()
+        poller.builder.loadModules.side_effect = error.MibLoadError()
+        poller.load_mibs(["a"])
+

--- a/test/snmp/test_mibs.py
+++ b/test/snmp/test_mibs.py
@@ -52,4 +52,3 @@ class TestMibProcessing(TestCase):
         poller.builder = Mock()
         poller.builder.loadModules.side_effect = error.MibLoadError()
         poller.load_mibs(["a"])
-

--- a/test/snmp/test_mibs.py
+++ b/test/snmp/test_mibs.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock
+
 from pysnmp.smi import error
 
 from splunk_connect_for_snmp.snmp.manager import Poller, isMIBResolved


### PR DESCRIPTION
# Description

When mib loading fails we catch the exception instead propagating it higher and stopping whole process.


Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I wrote unit tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings