### PR TITLE
fix: change the default udpConnectionTimeout

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.worker.logLevel | default "INFO" }}
             - name: UDP_CONNECTION_TIMEOUT
-              value: {{ .Values.worker.udpConnectionTimeout | default "1" | quote }}
+              value: {{ .Values.worker.udpConnectionTimeout | default "3" | quote }}
             - name: PROFILES_RELOAD_DELAY
               value: {{ .Values.worker.profilesReloadDelay | default "300" | quote }}
             - name: MIB_SOURCES

--- a/integration_tests/test_poller_integration.py
+++ b/integration_tests/test_poller_integration.py
@@ -296,8 +296,8 @@ class TestModifyProfilesFrequency:
             [f"{trap_external_ip},,2c,public,,,600,test_modify,f,"], "inventory.yaml"
         )
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
-        time.sleep(20)
-        search_string = """| mpreview index=netmetrics earliest=-15s | search profiles=test_modify frequency=7 """
+        time.sleep(30)
+        search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify frequency=7 """
         result_count, metric_count = splunk_single_search(setup_splunk, search_string)
         assert result_count > 0
         assert metric_count > 0
@@ -306,7 +306,7 @@ class TestModifyProfilesFrequency:
 @pytest.mark.usefixtures("setup_modify_profile")
 class TestModifyProfilesVarBinds:
     def test_sanity_varBinds_field(self, setup_splunk):
-        search_string = """| mpreview index=netmetrics earliest=-15s | search profiles=test_modify UDP-MIB"""
+        search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify UDP-MIB"""
         result_count, metric_count = splunk_single_search(setup_splunk, search_string)
         assert result_count > 0
         assert metric_count > 0

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -60,7 +60,7 @@ MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 IGNORE_EMPTY_VARBINDS = human_bool(os.getenv("IGNORE_EMPTY_VARBINDS", False))
 CONFIG_PATH = os.getenv("CONFIG_PATH", "/app/config/config.yaml")
 PROFILES_RELOAD_DELAY = int(os.getenv("PROFILES_RELOAD_DELAY", "300"))
-UDP_CONNECTION_TIMEOUT = int(os.getenv("UDP_CONNECTION_TIMEOUT", 1))
+UDP_CONNECTION_TIMEOUT = int(os.getenv("UDP_CONNECTION_TIMEOUT", 3))
 
 DEFAULT_STANDARD_MIBS = [
     "HOST-RESOURCES-MIB",


### PR DESCRIPTION
# Description

This PR changes the default udpConnectionTimeout of SNMP operations to 3 seconds.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement

## How Has This Been Tested?

Integration tests.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings