### PR TITLE
test: add retry mechanism to splunk queries of integration tests

### DIFF
--- a/integration_tests/test_poller_integration.py
+++ b/integration_tests/test_poller_integration.py
@@ -96,14 +96,14 @@ class TestProfiles:
     def test_static_profiles_metrics(self, setup_splunk):
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=generic_switch 
         | search "TCP-MIB" """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
         assert result_count > 0
         assert metric_count > 0
 
     def test_static_profiles_event(self, setup_splunk):
         search_string = """search index=netops sourcetype="sc4snmp:event" "IF-MIB.ifType" AND NOT "IF-MIB.ifAdminStatus" """
         logger.info("Integration test static profile - events")
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
         assert result_count > 0
         assert metric_count > 0
 
@@ -140,7 +140,7 @@ def setup_profiles(request):
 class TestProfilesWorkflow:
     def test_add_new_profile_and_reload(self, setup_splunk):
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=new_profile """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
         assert result_count > 0
         assert metric_count > 0
 
@@ -160,7 +160,7 @@ class TestProfilesWorkflow:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(70)
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=generic_switch earliest=-20s """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
         assert result_count == 0
         assert metric_count == 0
 
@@ -173,7 +173,7 @@ class TestProfilesWorkflow:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(40)
         search_string = """| mpreview index=netmetrics earliest=-20s """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
         assert result_count == 0
         assert metric_count == 0
 
@@ -212,7 +212,7 @@ def setup_smart_profiles(request):
 class TestSmartProfiles:
     def test_smart_profiles_field(self, setup_splunk):
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=smart_profile_field | search icmpOutDestUnreachs """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
         assert result_count > 0
         assert metric_count > 0
 
@@ -221,9 +221,7 @@ class TestSmartProfiles:
             "Integration test for fields base smart profiles with custom translations"
         )
         search_string_base = """| mpreview index=netmetrics| spath profiles | search profiles=smart_profile_field | search myCustomName1 """
-        result_count, metric_count = splunk_single_search(
-            setup_splunk, search_string_base
-        )
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string_base, 5)
         assert result_count > 0
         assert metric_count > 0
 
@@ -274,7 +272,7 @@ def setup_modify_profile(request):
 class TestModifyProfilesFrequency:
     def test_sanity_frequency_field(self, setup_splunk):
         search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify frequency=5 """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
         assert result_count > 0
         assert metric_count > 0
 
@@ -298,7 +296,7 @@ class TestModifyProfilesFrequency:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(30)
         search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify frequency=7 """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
         assert result_count > 0
         assert metric_count > 0
 
@@ -307,7 +305,7 @@ class TestModifyProfilesFrequency:
 class TestModifyProfilesVarBinds:
     def test_sanity_varBinds_field(self, setup_splunk):
         search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify UDP-MIB"""
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
         assert result_count > 0
         assert metric_count > 0
 
@@ -335,15 +333,15 @@ class TestModifyProfilesVarBinds:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(20)
         search_string = """| mpreview index=netmetrics earliest=-15s | search profiles=test_modify TCP-MIB """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
         assert result_count > 0
         assert metric_count > 0
         search_string = """| mpreview index=netmetrics  earliest=-15s | search profiles=test_modify | search icmpOutDestUnreachs """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
         assert result_count > 0
         assert metric_count > 0
         search_string = """| mpreview index=netmetrics earliest=-20s | search  laIndex | dedup metric_name:sc4snmp.UCD-SNMP-MIB.laIndex """
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
         assert result_count == 3
         assert metric_count == 3
 
@@ -375,7 +373,7 @@ class TestSmallWalk:
         search_string = (
             """| mpreview index=netmetrics earliest=-30s | search "TCP-MIB" """
         )
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
         assert result_count > 0
         assert metric_count > 0
 
@@ -384,13 +382,13 @@ class TestSmallWalk:
         search_string = (
             """| mpreview index=netmetrics earliest=-20s | search "TCP-MIB" """
         )
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
         assert result_count == 0
         assert metric_count == 0
         search_string = (
             """| mpreview index=netmetrics earliest=-20s | search "IP-MIB" """
         )
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
         assert result_count > 0
         assert metric_count > 0
 
@@ -407,6 +405,16 @@ class TestPoolingV3:
         upgrade_helm(["inventory.yaml", "scheduler_secrets.yaml"])
         time.sleep(40)
         search_string = """| mpreview index=netmetrics earliest=-20s"""
-        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
         assert result_count == 0
         assert metric_count == 0
+
+
+def run_retried_single_search(setup_splunk, search_string, retries):
+    for i in range(retries):
+        result_count, metric_count = splunk_single_search(setup_splunk, search_string)
+        if result_count or metric_count:
+            return result_count, metric_count
+        logger.info("No results returned from search. Retrying in 2 seconds...")
+        time.sleep(2)
+    return 0, 0

--- a/integration_tests/test_poller_integration.py
+++ b/integration_tests/test_poller_integration.py
@@ -96,14 +96,18 @@ class TestProfiles:
     def test_static_profiles_metrics(self, setup_splunk):
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=generic_switch 
         | search "TCP-MIB" """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 5
+        )
         assert result_count > 0
         assert metric_count > 0
 
     def test_static_profiles_event(self, setup_splunk):
         search_string = """search index=netops sourcetype="sc4snmp:event" "IF-MIB.ifType" AND NOT "IF-MIB.ifAdminStatus" """
         logger.info("Integration test static profile - events")
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 5
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -140,7 +144,9 @@ def setup_profiles(request):
 class TestProfilesWorkflow:
     def test_add_new_profile_and_reload(self, setup_splunk):
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=new_profile """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 5
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -160,7 +166,9 @@ class TestProfilesWorkflow:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(70)
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=generic_switch earliest=-20s """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 3
+        )
         assert result_count == 0
         assert metric_count == 0
 
@@ -173,7 +181,9 @@ class TestProfilesWorkflow:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(40)
         search_string = """| mpreview index=netmetrics earliest=-20s """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 3
+        )
         assert result_count == 0
         assert metric_count == 0
 
@@ -212,7 +222,9 @@ def setup_smart_profiles(request):
 class TestSmartProfiles:
     def test_smart_profiles_field(self, setup_splunk):
         search_string = """| mpreview index=netmetrics| spath profiles | search profiles=smart_profile_field | search icmpOutDestUnreachs """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 5
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -221,7 +233,9 @@ class TestSmartProfiles:
             "Integration test for fields base smart profiles with custom translations"
         )
         search_string_base = """| mpreview index=netmetrics| spath profiles | search profiles=smart_profile_field | search myCustomName1 """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string_base, 5)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string_base, 5
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -272,7 +286,9 @@ def setup_modify_profile(request):
 class TestModifyProfilesFrequency:
     def test_sanity_frequency_field(self, setup_splunk):
         search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify frequency=5 """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 8
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -296,7 +312,9 @@ class TestModifyProfilesFrequency:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(30)
         search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify frequency=7 """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 8
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -305,7 +323,9 @@ class TestModifyProfilesFrequency:
 class TestModifyProfilesVarBinds:
     def test_sanity_varBinds_field(self, setup_splunk):
         search_string = """| mpreview index=netmetrics earliest=-30s | search profiles=test_modify UDP-MIB"""
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 8
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -333,15 +353,21 @@ class TestModifyProfilesVarBinds:
         upgrade_helm(["inventory.yaml", "profiles.yaml"])
         time.sleep(20)
         search_string = """| mpreview index=netmetrics earliest=-15s | search profiles=test_modify TCP-MIB """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 3
+        )
         assert result_count > 0
         assert metric_count > 0
         search_string = """| mpreview index=netmetrics  earliest=-15s | search profiles=test_modify | search icmpOutDestUnreachs """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 3
+        )
         assert result_count > 0
         assert metric_count > 0
         search_string = """| mpreview index=netmetrics earliest=-20s | search  laIndex | dedup metric_name:sc4snmp.UCD-SNMP-MIB.laIndex """
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 3
+        )
         assert result_count == 3
         assert metric_count == 3
 
@@ -373,7 +399,9 @@ class TestSmallWalk:
         search_string = (
             """| mpreview index=netmetrics earliest=-30s | search "TCP-MIB" """
         )
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 8
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -382,13 +410,17 @@ class TestSmallWalk:
         search_string = (
             """| mpreview index=netmetrics earliest=-20s | search "TCP-MIB" """
         )
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 5)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 5
+        )
         assert result_count == 0
         assert metric_count == 0
         search_string = (
             """| mpreview index=netmetrics earliest=-20s | search "IP-MIB" """
         )
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 8)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 8
+        )
         assert result_count > 0
         assert metric_count > 0
 
@@ -400,12 +432,14 @@ class TestPoolingV3:
         create_v3_secrets()
         update_file(["- secretv4"], "scheduler_secrets.yaml")
         update_file(
-            [f"{trap_external_ip},,3,public,secretv4,,600,,,"], "inventory.yaml"
+            [f"{trap_external_ip},,3,snmp-poller,secretv4,,600,,,"], "inventory.yaml"
         )
         upgrade_helm(["inventory.yaml", "scheduler_secrets.yaml"])
         time.sleep(40)
         search_string = """| mpreview index=netmetrics earliest=-20s"""
-        result_count, metric_count = run_retried_single_search(setup_splunk, search_string, 3)
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 3
+        )
         assert result_count == 0
         assert metric_count == 0
 


### PR DESCRIPTION
# Description

This PR adds a mechanism of retrying splunk search in integration tests to avoid randomly failing CI pipelines.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement

## How Has This Been Tested?

N/A

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings