### PR TITLE
fix: replace celerybeatmongo repo 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -135,9 +135,9 @@ pymongo = "*"
 
 [package.source]
 type = "git"
-url = "https://github.com/rfaircloth-splunk/celerybeat-mongo"
+url = "https://github.com/splunk/celerybeat-mongo"
 reference = "main"
-resolved_reference = "2885863f796244404a0f97fd4fa78ff2f2fe922a"
+resolved_reference = "68b7afe958ccb59a1a1095e2a51c1fd26f1f7ecb"
 
 [[package]]
 name = "certifi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requests-cache = "^0.9.3"
 requests-ratelimiter = "^0.2.1"
 mongoengine = "^0.24.1"
 #celerybeat-mongo = "^0.2.0"
-celerybeat-mongo = {git="https://github.com/rfaircloth-splunk/celerybeat-mongo", branch="main"}
+celerybeat-mongo = {git="https://github.com/splunk/celerybeat-mongo", branch="main"}
 pysnmplib = "^5.0.5"
 PyYAML = "^6.0"
 #Note this is temporary PR to upstream project is issued


### PR DESCRIPTION
# Description

This PR replaces celerybeatmongo repository. It contains PR fixing `can't compare offset-naive and offset-aware datetimes` error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Integration tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings