### PR TITLE
doc: get rid off redundant sudos

### DIFF
--- a/docs/gettingstarted/mk8s/k8s-microk8s.md
+++ b/docs/gettingstarted/mk8s/k8s-microk8s.md
@@ -52,12 +52,11 @@ The following commands can be issued from any one node in a cluster
 
 ```bash
 sudo systemctl enable iscsid
-sudo microk8s enable helm3
-sudo microk8s enable storage
-sudo microk8s enable dns
-sudo microk8s enable rbac
-sudo microk8s enable community
-sudo microk8s enable openebs
+microk8s enable helm3
+microk8s enable storage
+microk8s enable rbac
+microk8s enable community
+microk8s enable openebs
 microk8s status --wait-ready
 ```
 


### PR DESCRIPTION
# Description

This PR deletes redundant sudo commands for microk8s and change the way of enabling dns addon.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement

## How Has This Been Tested?

N/A

## Checklist

N/A