### PR TITLE
fix: make task timeout configurable

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: {{ include "splunk-connect-for-snmp.celery_url" . }}
             - name: MONGO_URI
               value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
+            - name: CELERY_TASK_TIMEOUT
+              value: {{ .Values.worker.taskTimeout | default "2400" | quote }}
             {{- if .Values.worker.ignoreNotIncreasingOid }}
             - name: IGNORE_NOT_INCREASING_OIDS
               value: {{ join "," .Values.worker.ignoreNotIncreasingOid }}

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -97,6 +97,7 @@ worker:
   ignoreNotIncreasingOid: []
   replicaCount: 2
   concurrency: 4
+  taskTimeout: 2400
   nameOverride: ""
   fullnameOverride: ""
 
@@ -330,7 +331,7 @@ mongodb:
         prometheus.io/port: "9216"
 rabbitmq:
   extraConfiguration: |
-    consumer_timeout =  2400000
+    consumer_timeout =  7200000
   replicaCount: 1
   pdb:
     create: true

--- a/splunk_connect_for_snmp/celery_config.py
+++ b/splunk_connect_for_snmp/celery_config.py
@@ -26,7 +26,7 @@ import os
 
 MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 MONGO_DB_SCHEDULES = os.getenv("MONGO_DB_SCHEDULES", "schedules")
-
+CELERY_TASK_TIMEOUT = int(os.getenv("CELERY_TASK_TIMEOUT", "2400"))
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB_CELERY_DATABASE = os.getenv("MONGO_DB_CELERY_DATABASE", MONGO_DB)
 
@@ -48,5 +48,5 @@ worker_prefetch_multiplier = 1
 task_acks_on_failure_or_timeout = True
 task_reject_on_worker_lost = True
 task_track_started = True
-task_time_limit = 2400
+task_time_limit = CELERY_TASK_TIMEOUT
 task_ignore_result = True


### PR DESCRIPTION
# Description

This PR adds an option to make task timeout configurable. We found the problem, when walk process last longer than 40 minutes, that it timeouts the workers. It should be configurable.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings