### PR TITLE
fix: disable first full walk when small walk is enabled

### DIFF
--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -388,10 +388,7 @@ class Poller(Task):
             needed_mibs = []
             if walk and profiles:
                 # as we have base profile configured, we need to make sure that those two MIB families are walked
-                required_bulk = {
-                    "IF-MIB": None,
-                    "SNMPv2-MIB": None
-                }
+                required_bulk = {"IF-MIB": None, "SNMPv2-MIB": None}
             else:
                 required_bulk = {}
 

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -276,7 +276,6 @@ class Poller(Task):
         ir: InventoryRecord,
         walk: bool = False,
         profiles: List[str] = None,
-        walked_first_time=True,
     ):
         retry = False
         address = transform_address_to_key(ir.address, ir.port)
@@ -287,7 +286,7 @@ class Poller(Task):
             logger.debug("Profiles reloaded")
 
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = self.get_var_binds(
-            address, walk=walk, profiles=profiles, walked_first_time=walked_first_time
+            address, walk=walk, profiles=profiles
         )
 
         authData = GetAuth(logger, ir, self.snmpEngine)
@@ -378,16 +377,23 @@ class Poller(Task):
         logger.warning(f"no mib found {id} based on {oid} from {target}")
         return False, ""
 
-    def get_var_binds(self, address, walk=False, profiles=[], walked_first_time=True):
+    def get_var_binds(self, address, walk=False, profiles=[]):
         varbinds_bulk = set()
         varbinds_get = set()
         get_mapping = {}
         bulk_mapping = {}
-        if walk and (not walked_first_time or not profiles):
+        if walk and not profiles:
             varbinds_bulk.add(ObjectType(ObjectIdentity("1.3.6")))
         else:
             needed_mibs = []
-            required_bulk = {}
+            if walk and profiles:
+                # as we have base profile configured, we need to make sure that those two MIB families are walked
+                required_bulk = {
+                    "IF-MIB": None,
+                    "SNMPv2-MIB": None
+                }
+            else:
+                required_bulk = {}
 
             # First pass we only look at profiles for a full mib walk
             for profile in profiles:

--- a/splunk_connect_for_snmp/snmp/tasks.py
+++ b/splunk_connect_for_snmp/snmp/tasks.py
@@ -78,9 +78,7 @@ def walk(self, **kwargs):
         ir = get_inventory(mongo_inventory, address)
         retry = True
         while retry:
-            retry, result = self.do_work(
-                ir, walk=True, profiles=profile
-            )
+            retry, result = self.do_work(ir, walk=True, profiles=profile)
 
     # After a Walk tell schedule to recalc
     work = {}

--- a/splunk_connect_for_snmp/snmp/tasks.py
+++ b/splunk_connect_for_snmp/snmp/tasks.py
@@ -71,10 +71,6 @@ def walk(self, **kwargs):
     mongo_client = pymongo.MongoClient(MONGO_URI)
     mongo_db = mongo_client[MONGO_DB]
     mongo_inventory = mongo_db.inventory
-    mongo_targets = mongo_db.targets
-
-    walked_first_time = mongo_targets.find_one({"address": address})
-    logger.warning(walked_first_time)
 
     lock = MongoLock(client=mongo_client, db="sc4snmp")
 
@@ -83,7 +79,7 @@ def walk(self, **kwargs):
         retry = True
         while retry:
             retry, result = self.do_work(
-                ir, walk=True, profiles=profile, walked_first_time=walked_first_time
+                ir, walk=True, profiles=profile
             )
 
     # After a Walk tell schedule to recalc

--- a/test/snmp/test_get_varbinds.py
+++ b/test/snmp/test_get_varbinds.py
@@ -37,8 +37,8 @@ class TestGetVarbinds(TestCase):
             }
         }
 
-        Poller.profiles = profiles
-        Poller.load_mibs = Mock()
+        poller.profiles = profiles
+        poller.load_mibs = Mock()
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
         )
@@ -68,8 +68,8 @@ class TestGetVarbinds(TestCase):
             }
         }
 
-        Poller.profiles = profiles
-        Poller.load_mibs = Mock()
+        poller.profiles = profiles
+        poller.load_mibs = Mock()
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
         )
@@ -98,8 +98,8 @@ class TestGetVarbinds(TestCase):
             }
         }
 
-        Poller.profiles = profiles
-        Poller.load_mibs = Mock()
+        poller.profiles = profiles
+        poller.load_mibs = Mock()
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
         )

--- a/test/snmp/test_get_varbinds.py
+++ b/test/snmp/test_get_varbinds.py
@@ -26,14 +26,16 @@ class TestGetVarbinds(TestCase):
         poller = Poller.__new__(Poller)
 
         profiles = {
-            "test1": {"condition": {"type": "walk"},
-            "varBinds": [
-                ["IF-MIB", "ifInDiscards", 1],
-                ["IF-MIB", "ifOutErrors"],
-                ["SNMPv2-MIB", "sysDescr", 0],
-                ["IP-MIB"]
-            ],
-        }}
+            "test1": {
+                "condition": {"type": "walk"},
+                "varBinds": [
+                    ["IF-MIB", "ifInDiscards", 1],
+                    ["IF-MIB", "ifOutErrors"],
+                    ["SNMPv2-MIB", "sysDescr", 0],
+                    ["IP-MIB"],
+                ],
+            }
+        }
 
         Poller.profiles = profiles
         Poller.load_mibs = Mock()
@@ -48,19 +50,23 @@ class TestGetVarbinds(TestCase):
         walk_var_bind = list(varbinds_bulk)
 
         self.assertEqual(
-            {walk_var_bind[0]._ObjectType__args[0]._ObjectIdentity__args[0],
-             walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0],
-             walk_var_bind[2]._ObjectType__args[0]._ObjectIdentity__args[0]}, {"SNMPv2-MIB", "IF-MIB", "IP-MIB"}
+            {
+                walk_var_bind[0]._ObjectType__args[0]._ObjectIdentity__args[0],
+                walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0],
+                walk_var_bind[2]._ObjectType__args[0]._ObjectIdentity__args[0],
+            },
+            {"SNMPv2-MIB", "IF-MIB", "IP-MIB"},
         )
 
     def test_get_varbinds_for_walk_none(self):
         poller = Poller.__new__(Poller)
 
         profiles = {
-            "test1": {"condition": {"type": "walk"},
-                      "varBinds": [
-                      ],
-                      }}
+            "test1": {
+                "condition": {"type": "walk"},
+                "varBinds": [],
+            }
+        }
 
         Poller.profiles = profiles
         Poller.load_mibs = Mock()
@@ -75,18 +81,22 @@ class TestGetVarbinds(TestCase):
         walk_var_bind = list(varbinds_bulk)
 
         self.assertEqual(
-            {walk_var_bind[0]._ObjectType__args[0]._ObjectIdentity__args[0],
-             walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0]}, {"SNMPv2-MIB", "IF-MIB"}
+            {
+                walk_var_bind[0]._ObjectType__args[0]._ObjectIdentity__args[0],
+                walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0],
+            },
+            {"SNMPv2-MIB", "IF-MIB"},
         )
 
-    def test_get_varbinds_for_walk(self):
+    def test_get_varbinds_for_walk_with_three_profiles(self):
         poller = Poller.__new__(Poller)
 
         profiles = {
-            "test1": {"condition": {"type": "walk"},
-                      "varBinds": [["IP-MIB"], ["TCP-MIB"], ["UDP-MIB"]
-                      ],
-                      }}
+            "test1": {
+                "condition": {"type": "walk"},
+                "varBinds": [["IP-MIB"], ["TCP-MIB"], ["UDP-MIB"]],
+            }
+        }
 
         Poller.profiles = profiles
         Poller.load_mibs = Mock()
@@ -101,11 +111,14 @@ class TestGetVarbinds(TestCase):
         walk_var_bind = list(varbinds_bulk)
 
         self.assertEqual(
-            {walk_var_bind[0]._ObjectType__args[0]._ObjectIdentity__args[0],
-            walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0],
-            walk_var_bind[2]._ObjectType__args[0]._ObjectIdentity__args[0],
-            walk_var_bind[3]._ObjectType__args[0]._ObjectIdentity__args[0],
-             walk_var_bind[4]._ObjectType__args[0]._ObjectIdentity__args[0]}, {"SNMPv2-MIB", "IF-MIB", "UDP-MIB", "IP-MIB", "TCP-MIB"}
+            {
+                walk_var_bind[0]._ObjectType__args[0]._ObjectIdentity__args[0],
+                walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0],
+                walk_var_bind[2]._ObjectType__args[0]._ObjectIdentity__args[0],
+                walk_var_bind[3]._ObjectType__args[0]._ObjectIdentity__args[0],
+                walk_var_bind[4]._ObjectType__args[0]._ObjectIdentity__args[0],
+            },
+            {"SNMPv2-MIB", "IF-MIB", "UDP-MIB", "IP-MIB", "TCP-MIB"},
         )
 
     def test_get_varbinds_for_walk_next_time_no_profiles(self):


### PR DESCRIPTION
# Description

This PR changes the way small walk feature works. Doesn't make sense to traverse full tree with walk if customer knows from the very beginning what MIB families it he want to poll from.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Refactor/improvement

## How Has This Been Tested?

Manual tests, unit tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings