### PR TITLE
fix: worker pods recreation

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -104,72 +104,90 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "environmental-variables" -}}
-env:
-  - name: CONFIG_PATH
-    value: /app/config/config.yaml
-  - name: REDIS_URL
-    value: {{ include "splunk-connect-for-snmp.redis_url" . }}
-  - name: SC4SNMP_VERSION
-    value: {{ .Chart.Version | default "0.0.0" }}
-  - name: WORKER_CONCURRENCY
-    value: {{ .Values.worker.poller.concurrency | default "2" | quote }}
-  - name: PREFETCH_COUNT
-    value: {{ .Values.worker.poller.prefetch | default "1" | quote }}
-  - name: CELERY_BROKER_URL
-    value: {{ include "splunk-connect-for-snmp.celery_url" . }}
-  - name: MONGO_URI
-    value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
-  {{- if .Values.worker.ignoreNotIncreasingOid }}
-  - name: IGNORE_NOT_INCREASING_OIDS
-    value: {{ join "," .Values.worker.ignoreNotIncreasingOid }}
-  {{- end}}
-  {{- if .Values.sim.enabled }}
-  - name: OTEL_METRICS_URL
-    value: "http://{{ .Release.Name }}-{{ include "splunk-connect-for-snmp.name" . }}-sim:8882"
-  {{- end}}
-  - name: LOG_LEVEL
-    value: {{ .Values.worker.logLevel | default "INFO" }}
-  - name: UDP_CONNECTION_TIMEOUT
-    value: {{ .Values.worker.udpConnectionTimeout | default "3" | quote }}
-  - name: PROFILES_RELOAD_DELAY
-    value: {{ .Values.worker.profilesReloadDelay | default "300" | quote }}
-  - name: MIB_SOURCES
-    value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/asn1/@mib@"
-  - name: MIB_INDEX
-    value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/index.csv"
-  - name: MIB_STANDARD
-    value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/standard.txt"
-  {{- if .Values.splunk.enabled }}
-  {{- if .Values.splunk.protocol }}
-  - name: SPLUNK_HEC_SCHEME
-    value: {{ .Values.splunk.protocol | default "https" | quote }}
-  {{- end}}
-  - name: SPLUNK_HEC_HOST
-    value: {{ .Values.splunk.host | quote }}
-  - name: IGNORE_EMPTY_VARBINDS
-    value: {{ .Values.worker.ignoreEmptyVarbinds | default "false" | quote }}
-  {{- if .Values.splunk.port }}
-  - name: SPLUNK_HEC_PORT
-    value: {{ .Values.splunk.port | default "" | quote }}
-  {{- end}}
-  {{- if .Values.splunk.path }}
-  - name: SPLUNK_HEC_PATH
-    value: {{ .Values.splunk.path | default "/services/collector" | quote }}
-  {{- end}}
-  - name: SPLUNK_HEC_INSECURESSL
-    value: {{ .Values.splunk.insecureSSL | default "false" | quote }}
-  - name: SPLUNK_HEC_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: {{ include "splunk-connect-for-snmp.name" . }}-splunk
-        key: hec_token
-  {{- if .Values.splunk.eventIndex }}
-  - name: SPLUNK_HEC_INDEX_EVENTS
-    value: {{ .Values.splunk.eventIndex | default "netops" }}
-  {{- end}}
-  {{- if .Values.splunk.metricsIndex }}
-  - name: SPLUNK_HEC_INDEX_METRICS
-    value: {{ .Values.splunk.metricsIndex | default "netmetrics" }}
-  {{- end}}
-  {{- end}}
+- name: CONFIG_PATH
+  value: /app/config/config.yaml
+- name: REDIS_URL
+  value: {{ include "splunk-connect-for-snmp.redis_url" . }}
+- name: SC4SNMP_VERSION
+  value: {{ .Chart.Version | default "0.0.0" }}
+- name: CELERY_BROKER_URL
+  value: {{ include "splunk-connect-for-snmp.celery_url" . }}
+- name: MONGO_URI
+  value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
+- name: WALK_RETRY_MAX_INTERVAL
+  value: {{ .Values.worker.walkRetryMaxInterval | default "600" | quote }}
+{{- if .Values.worker.ignoreNotIncreasingOid }}
+- name: IGNORE_NOT_INCREASING_OIDS
+  value: {{ join "," .Values.worker.ignoreNotIncreasingOid }}
+{{- end}}
+{{- if .Values.sim.enabled }}
+- name: OTEL_METRICS_URL
+  value: "http://{{ .Release.Name }}-{{ include "splunk-connect-for-snmp.name" . }}-sim:8882"
+{{- end}}
+- name: LOG_LEVEL
+  value: {{ .Values.worker.logLevel | default "INFO" }}
+- name: UDP_CONNECTION_TIMEOUT
+  value: {{ .Values.worker.udpConnectionTimeout | default "3" | quote }}
+- name: PROFILES_RELOAD_DELAY
+  value: {{ .Values.worker.profilesReloadDelay | default "300" | quote }}
+- name: MIB_SOURCES
+  value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/asn1/@mib@"
+- name: MIB_INDEX
+  value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/index.csv"
+- name: MIB_STANDARD
+  value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/standard.txt"
+{{- if .Values.splunk.enabled }}
+{{- if .Values.splunk.protocol }}
+- name: SPLUNK_HEC_SCHEME
+  value: {{ .Values.splunk.protocol | default "https" | quote }}
+{{- end}}
+- name: SPLUNK_HEC_HOST
+  value: {{ .Values.splunk.host | quote }}
+- name: IGNORE_EMPTY_VARBINDS
+  value: {{ .Values.worker.ignoreEmptyVarbinds | default "false" | quote }}
+{{- if .Values.splunk.port }}
+- name: SPLUNK_HEC_PORT
+  value: {{ .Values.splunk.port | default "" | quote }}
+{{- end}}
+{{- if .Values.splunk.path }}
+- name: SPLUNK_HEC_PATH
+  value: {{ .Values.splunk.path | default "/services/collector" | quote }}
+{{- end}}
+- name: SPLUNK_HEC_INSECURESSL
+  value: {{ .Values.splunk.insecureSSL | default "false" | quote }}
+- name: SPLUNK_HEC_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "splunk-connect-for-snmp.name" . }}-splunk
+      key: hec_token
+{{- if .Values.splunk.eventIndex }}
+- name: SPLUNK_HEC_INDEX_EVENTS
+  value: {{ .Values.splunk.eventIndex | default "netops" }}
+{{- end}}
+{{- if .Values.splunk.metricsIndex }}
+- name: SPLUNK_HEC_INDEX_METRICS
+  value: {{ .Values.splunk.metricsIndex | default "netmetrics" }}
+{{- end}}
+{{- end}}
+{{- end }}
+
+{{- define "environmental-variables-poller" -}}
+- name: WORKER_CONCURRENCY
+  value: {{ .Values.worker.poller.concurrency | default "2" | quote }}
+- name: PREFETCH_COUNT
+  value: {{ .Values.worker.poller.prefetch | default "1" | quote }}
+{{- end }}
+
+{{- define "environmental-variables-sender" -}}
+- name: WORKER_CONCURRENCY
+  value: {{ .Values.worker.sender.concurrency | default "2" | quote }}
+- name: PREFETCH_COUNT
+  value: {{ .Values.worker.sender.prefetch | default "1" | quote }}
+{{- end }}
+
+{{- define "environmental-variables-trap" -}}
+- name: WORKER_CONCURRENCY
+  value: {{ .Values.worker.trap.concurrency | default "2" | quote }}
+- name: PREFETCH_COUNT
+  value: {{ .Values.worker.trap.prefetch | default "1" | quote }}
 {{- end }}

--- a/charts/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -37,7 +37,9 @@ spec:
             [
               "celery", "worker-poller",
             ]
-          {{- include "environmental-variables" . | nindent 10 }}
+          env:
+            {{- include "environmental-variables" . | nindent 12 }}
+            {{- include "environmental-variables-poller" . | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/charts/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -37,7 +37,9 @@ spec:
             [
               "celery", "worker-sender",
             ]
-          {{- include "environmental-variables" . | nindent 10 }}
+          env:
+            {{- include "environmental-variables" . | nindent 12 }}
+            {{- include "environmental-variables-sender" . | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/charts/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -37,7 +37,9 @@ spec:
             [
               "celery", "worker-trap",
             ]
-          {{- include "environmental-variables" . | nindent 10 }}
+          env:
+            {{- include "environmental-variables" . | nindent 12 }}
+            {{- include "environmental-variables-trap" . | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -95,6 +95,7 @@ scheduler:
 
 worker:
   taskTimeout: 2400
+  walkRetryMaxInterval: 600
   ignoreNotIncreasingOid: []
   poller:
     replicaCount: 2

--- a/splunk_connect_for_snmp/snmp/tasks.py
+++ b/splunk_connect_for_snmp/snmp/tasks.py
@@ -43,6 +43,7 @@ logger = get_task_logger(__name__)
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 CONFIG_PATH = os.getenv("CONFIG_PATH", "/app/config/config.yaml")
+WALK_RETRY_MAX_INTERVAL = int(os.getenv("WALK_RETRY_MAX_INTERVAL", "600"))
 OID_VALIDATOR = re.compile(r"^([0-2])((\.0)|(\.[1-9][0-9]*))*$")
 
 
@@ -50,8 +51,7 @@ OID_VALIDATOR = re.compile(r"^([0-2])((\.0)|(\.[1-9][0-9]*))*$")
     bind=True,
     base=Poller,
     retry_backoff=30,
-    retry_jitter=True,
-    retry_backoff_max=3600,
+    retry_backoff_max=WALK_RETRY_MAX_INTERVAL,
     max_retries=50,
     autoretry_for=(
         MongoLockLocked,


### PR DESCRIPTION
# Description

This PR fixes shared concurrency  and prefetch values being used across every worker type (so all of them are recreated if the values changed for just one). Additionally, max walk retry difference can be configured from Helm.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] This change requires a documentation update

## How Has This Been Tested?

Integration tests.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings