### PR TITLE
fix: inventory csv pod container creating

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
+++ b/charts/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "splunk-connect-for-snmp.scheduler.labels" . | nindent 4 }}
 data:
-{{- with (.Values.poller).inventory}}
   inventory.csv: |-
+{{- with (.Values.poller).inventory}}
 {{ . | indent 4}}
 {{- end }}

--- a/charts/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
+++ b/charts/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "splunk-connect-for-snmp.scheduler.labels" . | nindent 4 }}
 data:
-  inventory.csv: |-
-{{- with (.Values.poller).inventory}}
-{{ . | indent 4}}
+  inventory.csv: |
+{{- if (.Values.poller).inventory }}
+{{ .Values.poller.inventory | indent 4 }}
+{{ else }}
+    address,version,community,walk_interval,profiles,SmartProfiles,delete
 {{- end }}

--- a/charts/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
+++ b/charts/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
@@ -9,5 +9,5 @@ data:
 {{- if (.Values.poller).inventory }}
 {{ .Values.poller.inventory | indent 4 }}
 {{ else }}
-    address,version,community,walk_interval,profiles,SmartProfiles,delete
+    address,port,version,community,secret,securityEngine,walk_interval,profiles,SmartProfiles,delete
 {{- end }}

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -188,8 +188,6 @@ worker:
 
 poller:
   usernameSecrets: []
-  inventory: |
-    address,version,community,walk_interval,profiles,SmartProfiles,delete
 
 sim:
   enabled: false


### PR DESCRIPTION
# Description

When no `poller.inventory` is specified, there is a problem with an infinite `ContainerCreating` state.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Manual and integration tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings