### PR TITLE
fix: add helm repo update

### DIFF
--- a/.github/workflows/cd-pages.yaml
+++ b/.github/workflows/cd-pages.yaml
@@ -92,6 +92,9 @@ jobs:
           wget https://splunk.github.io/splunk-connect-for-snmp/index.yaml -P /tmp/origin || true
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add pysnmp-mibs https://pysnmp.github.io/mibs/charts
+          echo "$(helm repo search pysnmp-mibs)"
+          helm repo update
+          echo "$(helm repo search pysnmp-mibs)"
           helm dependency build charts/splunk-connect-for-snmp
           helm package charts/splunk-connect-for-snmp -d /tmp/package
           gh release upload $VERSION /tmp/package/*


### PR DESCRIPTION
# Description

Mibserver dependency version is stuck on `1.14.2`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

N/A

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings