### PR TITLE
fix: mibserver versioning

### DIFF
--- a/.github/workflows/cd-pages.yaml
+++ b/.github/workflows/cd-pages.yaml
@@ -92,6 +92,9 @@ jobs:
           wget https://splunk.github.io/splunk-connect-for-snmp/index.yaml -P /tmp/origin || true
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add pysnmp-mibs https://pysnmp.github.io/mibs/charts
+          echo "$(helm repo search pysnmp-mibs)"
+          helm repo update
+          echo "$(helm repo search pysnmp-mibs)"
           helm dependency build charts/splunk-connect-for-snmp
           helm package charts/splunk-connect-for-snmp -d /tmp/package
           gh release upload $VERSION /tmp/package/*

--- a/charts/splunk-connect-for-snmp/Chart.lock
+++ b/charts/splunk-connect-for-snmp/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 16.8.10
 - name: mibserver
   repository: https://pysnmp.github.io/mibs/charts/
-  version: 1.14.2
-digest: sha256:882ca6e0cd371b94f1f1f06861f593b515b908e7504d40d187595ecdb863c4c6
-generated: "2022-06-15T16:29:53.985105+02:00"
+  version: 1.14.5
+digest: sha256:5c4dede67eaf5caba27ec8c4de8b34a7902c3c8f015ff198aeacd0e6e776b973
+generated: "2022-09-02T12:42:56.569024+02:00"


### PR DESCRIPTION
# Description

Mibserver dependency version is stuck on `1.14.2`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

N/A

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings