### PR TITLE
fix: add another way of mounting sim secrets

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -159,7 +159,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_INT_TESTS }}
         working-directory: ./integration_tests/scripts
       - name: Run integration tests
-        run: sleep 30 && timeout 50m ansible-playbook -v playbook.yml || true
+        run: sleep 30 && timeout 55m ansible-playbook -v playbook.yml || true
         working-directory: ./integration_tests/scripts
       - name: Download and analyze logs
         run: |

--- a/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
+++ b/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sim.secret.create }}
+{{- if and .Values.sim.secret.create .Values.sim.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
+++ b/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sim.enabled }}
+{{- if .Values.sim.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/splunk-connect-for-snmp/templates/sim/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/sim/_helpers.tpl
@@ -60,3 +60,15 @@ Create the name of the service account to use
 {{- default "default" .Values.sim.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define name for the Splunk Secret
+*/}}
+{{- define "splunk-connect-for-snmp.sim.secret" -}}
+{{- if .Values.sim.secret.name -}}
+{{- printf "%s" .Values.sim.secret.name -}}
+{{- else -}}
+{{ include "splunk-connect-for-snmp.name" . }}-sim
+{{- end -}}
+{{- end -}}
+

--- a/charts/splunk-connect-for-snmp/templates/sim/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/sim/deployment.yaml
@@ -14,10 +14,11 @@ spec:
       {{- include "splunk-connect-for-snmp.sim.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.sim.podAnnotations }}
       annotations:
+      {{- with .Values.sim.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/common/sim-secret.yaml") . | sha256sum }}
       labels:
         {{- include "splunk-connect-for-snmp.sim.selectorLabels" . | nindent 8 }}
     spec:
@@ -39,12 +40,12 @@ spec:
             - name: signalfxToken
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "splunk-connect-for-snmp.name" . }}-sim
+                  name: {{ include "splunk-connect-for-snmp.sim.secret" . }}
                   key: signalfxToken
             - name: signalfxRealm
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "splunk-connect-for-snmp.name" . }}-sim
+                  name: {{ include "splunk-connect-for-snmp.sim.secret" . }}
                   key: signalfxRealm
           ports:
             - containerPort: 8882

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -235,6 +235,14 @@ sim:
 
   service:
     annotations: {}
+
+  secret:
+    # Option for creating a new secret or using an existing one.
+    # When secret.create=true, a new kubernetes secret will be created by the helm chart that will contain the
+    # values from sim.signalfxToken and sim.signalfxRealm.
+    # When secret.create=false, the user must set secret.name to a name of a k8s secret the user created.
+    create: true
+    name: ""
 traps:
   replicaCount: 2
   usernameSecrets: []

--- a/docs/configuration/sim-configuration.md
+++ b/docs/configuration/sim-configuration.md
@@ -1,6 +1,6 @@
-# Otel configuration
+# OTEL and Splunk Observability Cloud configuration
 
-Splunk OpenTelemetry Collector is a component that provides an option to send metrics to SignalFx.
+Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
 In order to use it, you must set `enabled` flag in `values.yaml` to `true`:
 
 ```yaml
@@ -9,7 +9,11 @@ sim:
   enabled: true
 ```
 
-Also, you need to specify SignalFx token and realm, so at the end sim element in `values.yaml` looks like this:
+## Token and realm
+
+You need to specify Splunk Observability Cloud token and realm. There are two ways of configuring them:
+
+1. Pass those in a plain text via `values.yaml` so at the end sim element in looks like this:
 
 ```yaml
 sim:
@@ -17,6 +21,37 @@ sim:
   signalfxToken: BCwaJ_Ands4Xh7Nrg
   signalfxRealm: us0
 ```
+
+2. Alternatively, create microk8s secret by yourself and pass its name in `values.yaml` file. Create secret:
+
+```
+microk8s kubectl create -n <namespace> secret generic <secretname> \
+  --from-literal=signalfxToken=<signalfxToken> \
+  --from-literal=signalfxRealm=<signalfxRealm>
+```
+
+Modify `sim.secret` section of `values.yaml`. Disable creation of the secret with `sim.secret.create` and provide the
+`<secretname>` matching the one from the previous step. Pass it via `sim.secret.name`. For example, for `<secretname>`=`signalfx`
+the `sim` section would look like:
+
+```yaml
+sim:
+  secret:
+    create: false
+    name: signalfx
+```
+
+### Define annotations
+In case you need to append some annotations to the `sim` service, you can do it by setting `sim.service.annotations`, for ex.:
+
+```yaml
+sim:
+  service:
+    annotations:
+      annotation_key: annotation_value
+```
+
+## Verify the deployment
 
 After executing `microk8s helm3 upgrade --install snmp -f values.yaml splunk-connect-for-snmp/splunk-connect-for-snmp --namespace=sc4snmp --create-namespace
 `, the sim pod should be up and running:
@@ -33,14 +68,4 @@ snmp-mongodb-869cc8586f-vvr9f                                 2/2     Running   
 snmp-redis-master-0                                           1/1     Running   0          133m
 snmp-splunk-connect-for-snmp-trap-78759bfc8b-79m6d            1/1     Running   0          99m
 snmp-splunk-connect-for-snmp-sim-59b89747f-kn6tf              1/1     Running   0          32s
-```
-
-### Define annotations
-In case you need to append some annotations to the `sim` service, you can do it by setting `sim.service.annotations`, for ex.:
-
-```yaml
-sim:
-  service:
-    annotations:
-      annotation_key: annotation_value
 ```

--- a/docs/configuration/sim-configuration.md
+++ b/docs/configuration/sim-configuration.md
@@ -13,7 +13,7 @@ sim:
 
 You need to specify Splunk Observability Cloud token and realm. There are two ways of configuring them:
 
-1. Pass those in a plain text via `values.yaml` so at the end sim element in looks like this:
+1. Pass those in a plain text via `values.yaml` so at the end sim element looks like this:
 
 ```yaml
 sim:
@@ -40,6 +40,11 @@ sim:
     create: false
     name: signalfx
 ```
+
+Note: After the initial installation, if you change `sim.signalfxToken` and/or `sim.signalfxRealm` and no `sim.secret.name` is given, 
+the `sim` pod will sense the update by itself (after `helm3 upgrade` command) and trigger the recreation. But, when you edit secret created outside
+of `values.yaml` (given by `sim.secret.name`), you need to roll out the deployment by yourself or delete the pod to update the data.
+
 
 ### Define annotations
 In case you need to append some annotations to the `sim` service, you can do it by setting `sim.service.annotations`, for ex.:


### PR DESCRIPTION
# Description

This PR adds:
1. a way to use your own secret to log into the SignalFx
2. reloading pod when signalfxToken/signalfxRealm changes

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Refactor/improvement
- [x] This change requires a documentation update

## How Has This Been Tested?

Manual tests, integration tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings