### PR TITLE
fix: otel image for chart appversion

### DIFF
--- a/create_packages.sh
+++ b/create_packages.sh
@@ -226,13 +226,14 @@ docker save $docker_image_pull > /tmp/package/packages/sim_image.tar
 # Download and package otel charts
 cd /tmp/package/packages/ || exit
 LOCATION=$(curl -s https://api.github.com/repos/signalfx/splunk-otel-collector-chart/releases/latest | grep "zipball_url" | awk '{ print $2 }' | sed 's/,$//' | sed 's/"//g' )
-otel_image=quay.io/signalfx/splunk-otel-collector:$(echo $LOCATION | sed 's/.*zipball\/splunk-otel-collector-//g')
-docker pull "$otel_image"
-docker save $otel_image > /tmp/package/packages/otel_image.tar
 curl -L -o otel-repo.zip $LOCATION
 unzip otel-repo.zip
 rm otel-repo.zip
 OTEL_DIR=$(ls | grep -E "signalfx-splunk.+")
 CHART_DIT="$OTEL_DIR/helm-charts/splunk-otel-collector"
+OTEL_IMAGE_TAG=$(cat $CHART_DIT/Chart.yaml | grep appVersion | sed 's/.*: //g')
+otel_image=quay.io/signalfx/splunk-otel-collector:"$OTEL_IMAGE_TAG"
+docker pull "$otel_image"
+docker save $otel_image > /tmp/package/packages/otel_image.tar
 helm package $CHART_DIT -d /tmp/package/packages/
 rm -rf $OTEL_DIR


### PR DESCRIPTION
# Description

Get OTEL image from appVersion from Chart.yaml instead of from chart file name.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

N?A

## Checklist

N/A