### PR TITLE
doc: modify installation profile

### DIFF
--- a/docs/configuration/configuring-profiles.md
+++ b/docs/configuration/configuring-profiles.md
@@ -25,7 +25,7 @@ scheduler:
       #Name of profile
       basev1:
         # Define frequency for profile
-        frequency: 10
+        frequency: 100
         #Define condition
         condition:
           # Define type of condition. Allowed value field, base and walk
@@ -48,7 +48,7 @@ For example, we have configured two profiles. One is smart, and the other one is
 scheduler:
     profiles: |
       smart_profile:
-        frequency: 10
+        frequency: 100
         condition:
           type: field
           field: "SNMPv2-MIB.sysDescr"
@@ -188,7 +188,7 @@ Example of `base` type profile:
 scheduler:
     profiles: |
       SmartProfile_base_example:
-        frequency: 10
+        frequency: 100
         condition: 
           type: "base"
         varBinds:
@@ -201,7 +201,7 @@ Example of `field`  type profile, also called an automatic profile:
 scheduler:
     profiles: |
       SmartProfile_field_example:
-        frequency: 10
+        frequency: 100
         condition: 
           type: "field"
           field: "SNMPv2-MIB.sysDescr"

--- a/docs/gettingstarted/sc4snmp-installation.md
+++ b/docs/gettingstarted/sc4snmp-installation.md
@@ -82,13 +82,13 @@ scheduler:
   logLevel: "INFO"
 #  profiles: |
 #    generic_switch:
-#      frequency: 60
+#      frequency: 300
 #      varBinds:
 #        - ['SNMPv2-MIB', 'sysDescr']
 #        - ['SNMPv2-MIB', 'sysName', 0]
+#        - ['TCP-MIB', 'tcpActiveOpens']
+#        - ['TCP-MIB', 'tcpAttemptFails']
 #        - ['IF-MIB']
-#        - ['TCP-MIB']
-#        - ['UDP-MIB']
 poller:
  # usernameSecrets:
  #   - sc4snmp-hlab-sha-aes

--- a/docs/offlineinstallation/offline-sc4snmp.md
+++ b/docs/offlineinstallation/offline-sc4snmp.md
@@ -109,13 +109,13 @@ scheduler:
   logLevel: "INFO"
 #  profiles: |
 #    generic_switch:
-#      frequency: 60
+#      frequency: 300
 #      varBinds:
 #        - ['SNMPv2-MIB', 'sysDescr']
 #        - ['SNMPv2-MIB', 'sysName', 0]
+#        - ['TCP-MIB', 'tcpActiveOpens']
+#        - ['TCP-MIB', 'tcpAttemptFails']
 #        - ['IF-MIB']
-#        - ['TCP-MIB']
-#        - ['UDP-MIB']
 poller:
  # usernameSecrets:
  #   - sc4snmp-hlab-sha-aes

--- a/docs/small-environment.md
+++ b/docs/small-environment.md
@@ -98,13 +98,13 @@ scheduler:
        memory: 180Mi
 #  profiles: |
 #    generic_switch:
-#      frequency: 60
+#      frequency: 300
 #      varBinds:
 #        - ['SNMPv2-MIB', 'sysDescr']
 #        - ['SNMPv2-MIB', 'sysName', 0]
+#        - ['TCP-MIB', 'tcpActiveOpens']
+#        - ['TCP-MIB', 'tcpAttemptFails']
 #        - ['IF-MIB']
-#        - ['TCP-MIB']
-#        - ['UDP-MIB']
 poller:
  # usernameSecrets:
  #   - sc4snmp-hlab-sha-aes


### PR DESCRIPTION
# Description

Decrease the frequency of the default profiles to not to suggest querying all MIB families every 60 seconds.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement

## How Has This Been Tested?

N/A

## Checklist

N/A