### PR TITLE
fix: add nodeport to trap service

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.traps.service.port }}
-      {{- if and .Values.traps.nodePort (eq .Values.traps.service.type "NodePort")}}
+      {{- if and .Values.traps.service.nodePort (eq .Values.traps.service.type "NodePort")}}
       nodePort: {{ .Values.traps.service.nodePort | default 30000 }}
       {{- end }}
       targetPort: 2162

--- a/charts/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -23,6 +23,9 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.traps.service.port }}
+      {{- if and .Values.traps.nodePort (eq .Values.traps.service.type "NodePort")}}
+      nodePort: {{ .Values.traps.nodePort | default 3000 }}
+      {{- end }}
       targetPort: 2162
       protocol: UDP
       name: snmp-udp

--- a/charts/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -24,7 +24,7 @@ spec:
   ports:
     - port: {{ .Values.traps.service.port }}
       {{- if and .Values.traps.nodePort (eq .Values.traps.service.type "NodePort")}}
-      nodePort: {{ .Values.traps.nodePort | default 3000 }}
+      nodePort: {{ .Values.traps.service.nodePort | default 30000 }}
       {{- end }}
       targetPort: 2162
       protocol: UDP

--- a/docs/configuration/trap-configuration.md
+++ b/docs/configuration/trap-configuration.md
@@ -84,8 +84,9 @@ An example of SNMPv3 trap is:
 snmptrap -v3 -e 80003a8c04 -l authPriv -u snmp-poller -a SHA -A PASSWORD1 -x AES -X PASSWORD1 10.202.13.233 '' 1.3.6.1.2.1.2.2.1.1.1
 ```
 
-### Define load balancer IP
+### Define external gateway for traps
 
+If you use SC4SNMP standalone, configure `loadBalancerIP`.
 `loadBalancerIP` is the IP address in the metallb pool. 
 Example:
 
@@ -93,6 +94,23 @@ Example:
 traps:
   loadBalancerIP: 10.202.4.202
 ```
+
+If you want to use SC4SNMP trap receiver in K8S cluster, configure `NodePort` instead. The snippet of config is:
+
+```yaml
+traps:
+  service: 
+    type: NodePort
+    externalTrafficPolicy: Cluster
+    nodePort: 30000
+```
+
+Using this method, SNMP trap will always be forwarded to one of the trap receiver pods listening on port 30000 (as in the
+example above, remember - you can configure any other port). So doesn't matter IP address of which node you use, adding
+nodePort will make it end up in a correct place everytime. 
+
+Here, good practice is to create IP floating address/Anycast pointing to healthy nodes, so the traffic is forwarded in case of the
+failover. The best way is to create LoadBalancer which balance the traffic between nodes.
 
 ### Define number of traps server replica
 `replicaCount` defines that the number of replicas for trap container should be 2x number of nodes. The default value is `2`. 

--- a/docs/configuration/trap-configuration.md
+++ b/docs/configuration/trap-configuration.md
@@ -109,8 +109,8 @@ Using this method, SNMP trap will always be forwarded to one of the trap receive
 example above, remember - you can configure any other port). So doesn't matter IP address of which node you use, adding
 nodePort will make it end up in a correct place everytime. 
 
-Here, good practice is to create IP floating address/Anycast pointing to healthy nodes, so the traffic is forwarded in case of the
-failover. The best way is to create LoadBalancer which balance the traffic between nodes.
+Here, good practice is to create IP floating address/Anycast pointing to the healthy nodes, so the traffic is forwarded in case of the
+failover. The best way is to create external LoadBalancer which balance the traffic between nodes.
 
 ### Define number of traps server replica
 `replicaCount` defines that the number of replicas for trap container should be 2x number of nodes. The default value is `2`. 

--- a/splunk_connect_for_snmp/splunk/tasks.py
+++ b/splunk_connect_for_snmp/splunk/tasks.py
@@ -141,9 +141,7 @@ def do_send(data, destination_url, self):
             pass
         # These errors can't be retried
         elif response.status_code in (403, 401, 400):
-            logger.error(
-                f"Response code is {response.status_code} {response.text}"
-            )
+            logger.error(f"Response code is {response.status_code} {response.text}")
         # These can be but are not exceptions so we will setup retry ourself
         elif response.status_code in (500, 503):
             logger.warning(f"Response code is {response.status_code} {response.text}")

--- a/splunk_connect_for_snmp/splunk/tasks.py
+++ b/splunk_connect_for_snmp/splunk/tasks.py
@@ -142,7 +142,7 @@ def do_send(data, destination_url, self):
         # These errors can't be retried
         elif response.status_code in (403, 401, 400):
             logger.error(
-                f"Response code is {response.status_code} {response.text} headers were {SPLUNK_HEC_HEADERS}"
+                f"Response code is {response.status_code} {response.text}"
             )
         # These can be but are not exceptions so we will setup retry ourself
         elif response.status_code in (500, 503):


### PR DESCRIPTION
# Description

Add option to configure nodePort for traps service, what makes configuration of a multnode environment easier.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

N/A

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings