### PR TITLE
fix: helm metrics indexing enabled issue

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -117,7 +117,7 @@ Create the name of the service account to use
 - name: WALK_RETRY_MAX_INTERVAL
   value: {{ .Values.worker.walkRetryMaxInterval | default "600" | quote }}
 - name: METRICS_INDEXING_ENABLED
-  value: {{ .Values.poller.metricsIndexingEnabled | default "false" | quote }}
+  value: {{ (.Values.poller).metricsIndexingEnabled | default "false" | quote }}
 {{- if .Values.worker.ignoreNotIncreasingOid }}
 - name: IGNORE_NOT_INCREASING_OIDS
   value: {{ join "," .Values.worker.ignoreNotIncreasingOid }}


### PR DESCRIPTION
# Description

Fix helm issue when poller is empty in main values.yaml file:

```
 executing "environmental-variables" at <.Values.poller.metricsIndexingEnabled>: nil pointer evaluating interface {}.metricsIndexingEnabled
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

N/A

## Checklist

N/A