### PR TITLE
doc: add channel to microk8s installation instruction

### DIFF
--- a/docs/gettingstarted/mk8s/k8s-microk8s.md
+++ b/docs/gettingstarted/mk8s/k8s-microk8s.md
@@ -22,7 +22,7 @@ may be found in the MicroK8s [documentation](https://microk8s.io/docs) including
 ## Install MicroK8s using Snap
 
 ```bash
-sudo snap install microk8s --classic
+sudo snap install microk8s --classic --channel=1.25/stable
 ```
 
 Add a user to the microk8s group so the `sudo` command is no longer necessary:


### PR DESCRIPTION
# Description

This PR adds a concrete version of microk8s to be installed, as from 1.26v one of the api that we still use in mibserver is deprecated. This hot fix will be deleted when the new version of the mibserver is ready.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Manual test.

## Checklist

N/A