### PR TITLE
fix: refactor varBinds mechanism and implement compound indexes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -632,7 +632,7 @@ wcwidth = "*"
 
 [[package]]
 name = "pycryptodomex"
-version = "3.15.0"
+version = "3.17"
 description = "Cryptographic library for Python"
 category = "main"
 optional = false
@@ -721,7 +721,7 @@ docs = ["furo (>=2022.3.4,<2023.0.0)", "myst-parser (>=0.17)", "sphinx (>=4.3.0,
 
 [[package]]
 name = "pysnmp-pyasn1"
-version = "1.1.2"
+version = "1.1.3"
 description = "ASN.1 types and codecs"
 category = "main"
 optional = false
@@ -741,16 +741,23 @@ requests = ">=2.26.0,<3.0.0"
 
 [[package]]
 name = "pysnmplib"
-version = "5.0.17"
+version = "5.0.21"
 description = ""
 category = "main"
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = "^3.8"
+develop = false
 
 [package.dependencies]
-pycryptodomex = ">=3.11.0,<4.0.0"
-pysnmp-pyasn1 = ">=1.0.3,<2.0.0"
-pysnmp-pysmi = ">=1.0.4,<2.0.0"
+pycryptodomex = "^3.11.0"
+pysnmp-pyasn1 = "^1.0.3"
+pysnmp-pysmi = "^1.0.4"
+
+[package.source]
+type = "git"
+url = "https://github.com/pysnmp/pysnmp.git"
+reference = "main"
+resolved_reference = "8f492d3782b26db88e2ea861da9ece413b074777"
 
 [[package]]
 name = "pytest"
@@ -1121,7 +1128,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5c1adc3293b8d5039cd99f1e68ff1c0ff83f15f48f08f2168110432f5e076ea8"
+content-hash = "cc8ac61bad91cfe1a3a6f28bbd7faf0e1c0b27921183579a1bdadf57c008373a"
 
 [metadata.files]
 amqp = [
@@ -1398,39 +1405,39 @@ prompt-toolkit = [
     {file = "prompt_toolkit-3.0.30.tar.gz", hash = "sha256:859b283c50bde45f5f97829f77a4674d1c1fcd88539364f1b28a37805cfd89c0"},
 ]
 pycryptodomex = [
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:6f5b6ba8aefd624834bc177a2ac292734996bb030f9d1b388e7504103b6fcddf"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:4540904c09704b6f831059c0dfb38584acb82cb97b0125cd52688c1f1e3fffa6"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:0fadb9f7fa3150577800eef35f62a8a24b9ddf1563ff060d9bd3af22d3952c8c"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:fc9bc7a9b79fe5c750fc81a307052f8daabb709bdaabb0fb18fb136b66b653b5"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:f8be976cec59b11f011f790b88aca67b4ea2bd286578d0bd3e31bcd19afcd3e4"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-manylinux2014_aarch64.whl", hash = "sha256:78d9621cf0ea35abf2d38fa2ca6d0634eab6c991a78373498ab149953787e5e5"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-musllinux_1_1_aarch64.whl", hash = "sha256:7db44039cc8b449bd08ab338a074e87093bd170f1a1b76d2fcef8a3e2ee11199"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-win32.whl", hash = "sha256:b6306403228edde6e289f626a3908a2f7f67c344e712cf7c0a508bab3ad9e381"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:48697790203909fab02a33226fda546604f4e2653f9d47bc5d3eb40879fa7c64"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:18e2ab4813883ae63396c0ffe50b13554b32bb69ec56f0afaf052e7a7ae0d55b"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:3709f13ca3852b0b07fc04a2c03b379189232b24007c466be0f605dd4723e9d4"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:191e73bc84a8064ad1874dba0ebadedd7cce4dedee998549518f2c74a003b2e1"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:e3164a18348bd53c69b4435ebfb4ac8a4076291ffa2a70b54f0c4b80c7834b1d"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27mu-manylinux2014_aarch64.whl", hash = "sha256:5676a132169a1c1a3712edf25250722ebc8c9102aa9abd814df063ca8362454f"},
-    {file = "pycryptodomex-3.15.0-cp27-cp27mu-musllinux_1_1_aarch64.whl", hash = "sha256:781efd04ea6762bb2ef7d4fa632c9c89895433744b6c345bd0c239d5ab058dfc"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e2b12968522a0358b8917fc7b28865acac002f02f4c4c6020fcb264d76bfd06d"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-manylinux1_i686.whl", hash = "sha256:e47bf8776a7e15576887f04314f5228c6527b99946e6638cf2f16da56d260cab"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:996e1ba717077ce1e6d4849af7a1426f38b07b3d173b879e27d5e26d2e958beb"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-manylinux2010_i686.whl", hash = "sha256:65204412d0c6a8e3c41e21e93a5e6054a74fea501afa03046a388cf042e3377a"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:dd452a5af7014e866206d41751886c9b4bf379a339fdf2dbfc7dd16c0fb4f8e0"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:b9279adc16e4b0f590ceff581f53a80179b02cba9056010d733eb4196134a870"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:04a5d6a17560e987272fc1763e9772a87689a08427b8cbdebe3ca7cba95d6156"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-win32.whl", hash = "sha256:46b3f05f2f7ac7841053da4e0f69616929ca3c42f238c405f6c3df7759ad2780"},
-    {file = "pycryptodomex-3.15.0-cp35-abi3-win_amd64.whl", hash = "sha256:8eecdf9cdc7343001d047f951b9cc805cd68cb6cd77b20ea46af5bffc5bd3dfb"},
-    {file = "pycryptodomex-3.15.0-pp27-pypy_73-macosx_10_9_x86_64.whl", hash = "sha256:67e1e6a92151023ccdfcfbc0afb3314ad30080793b4c27956ea06ab1fb9bcd8a"},
-    {file = "pycryptodomex-3.15.0-pp27-pypy_73-manylinux1_x86_64.whl", hash = "sha256:c4cb9cb492ea7dcdf222a8d19a1d09002798ea516aeae8877245206d27326d86"},
-    {file = "pycryptodomex-3.15.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:94c7b60e1f52e1a87715571327baea0733708ab4723346598beca4a3b6879794"},
-    {file = "pycryptodomex-3.15.0-pp27-pypy_73-win32.whl", hash = "sha256:04cc393045a8f19dd110c975e30f38ed7ab3faf21ede415ea67afebd95a22380"},
-    {file = "pycryptodomex-3.15.0-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0776bfaf2c48154ab54ea45392847c1283d2fcf64e232e85565f858baedfc1fa"},
-    {file = "pycryptodomex-3.15.0-pp36-pypy36_pp73-manylinux1_x86_64.whl", hash = "sha256:463119d7d22d0fc04a0f9122e9d3e6121c6648bcb12a052b51bd1eed1b996aa2"},
-    {file = "pycryptodomex-3.15.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:a07a64709e366c2041cd5cfbca592b43998bf4df88f7b0ca73dca37071ccf1bd"},
-    {file = "pycryptodomex-3.15.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:35a8f7afe1867118330e2e0e0bf759c409e28557fb1fc2fbb1c6c937297dbe9a"},
-    {file = "pycryptodomex-3.15.0.tar.gz", hash = "sha256:7341f1bb2dadb0d1a0047f34c3a58208a92423cdbd3244d998e4b28df5eac0ed"},
+    {file = "pycryptodomex-3.17-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:12056c38e49d972f9c553a3d598425f8a1c1d35b2e4330f89d5ff1ffb70de041"},
+    {file = "pycryptodomex-3.17-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ab33c2d9f275e05e235dbca1063753b5346af4a5cac34a51fa0da0d4edfb21d7"},
+    {file = "pycryptodomex-3.17-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:caa937ff29d07a665dfcfd7a84f0d4207b2ebf483362fa9054041d67fdfacc20"},
+    {file = "pycryptodomex-3.17-cp27-cp27m-manylinux2014_aarch64.whl", hash = "sha256:db23d7341e21b273d2440ec6faf6c8b1ca95c8894da612e165be0b89a8688340"},
+    {file = "pycryptodomex-3.17-cp27-cp27m-musllinux_1_1_aarch64.whl", hash = "sha256:f854c8476512cebe6a8681cc4789e4fcff6019c17baa0fd72b459155dc605ab4"},
+    {file = "pycryptodomex-3.17-cp27-cp27m-win32.whl", hash = "sha256:a57e3257bacd719769110f1f70dd901c5b6955e9596ad403af11a3e6e7e3311c"},
+    {file = "pycryptodomex-3.17-cp27-cp27m-win_amd64.whl", hash = "sha256:d38ab9e53b1c09608ba2d9b8b888f1e75d6f66e2787e437adb1fecbffec6b112"},
+    {file = "pycryptodomex-3.17-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:3c2516b42437ae6c7a29ef3ddc73c8d4714e7b6df995b76be4695bbe4b3b5cd2"},
+    {file = "pycryptodomex-3.17-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5c23482860302d0d9883404eaaa54b0615eefa5274f70529703e2c43cc571827"},
+    {file = "pycryptodomex-3.17-cp27-cp27mu-manylinux2014_aarch64.whl", hash = "sha256:7a8dc3ee7a99aae202a4db52de5a08aa4d01831eb403c4d21da04ec2f79810db"},
+    {file = "pycryptodomex-3.17-cp27-cp27mu-musllinux_1_1_aarch64.whl", hash = "sha256:7cc28dd33f1f3662d6da28ead4f9891035f63f49d30267d3b41194c8778997c8"},
+    {file = "pycryptodomex-3.17-cp35-abi3-macosx_10_9_universal2.whl", hash = "sha256:2d4d395f109faba34067a08de36304e846c791808524614c731431ee048fe70a"},
+    {file = "pycryptodomex-3.17-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:55eed98b4150a744920597c81b3965b632038781bab8a08a12ea1d004213c600"},
+    {file = "pycryptodomex-3.17-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:7fa0b52df90343fafe319257b31d909be1d2e8852277fb0376ba89d26d2921db"},
+    {file = "pycryptodomex-3.17-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78f0ddd4adc64baa39b416f3637aaf99f45acb0bcdc16706f0cc7ebfc6f10109"},
+    {file = "pycryptodomex-3.17-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4fa037078e92c7cc49f6789a8bac3de06856740bb2038d05f2d9a2e4b165d59"},
+    {file = "pycryptodomex-3.17-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:88b0d5bb87eaf2a31e8a759302b89cf30c97f2f8ca7d83b8c9208abe8acb447a"},
+    {file = "pycryptodomex-3.17-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:6feedf4b0e36b395329b4186a805f60f900129cdf0170e120ecabbfcb763995d"},
+    {file = "pycryptodomex-3.17-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:7a6651a07f67c28b6e978d63aa3a3fccea0feefed9a8453af3f7421a758461b7"},
+    {file = "pycryptodomex-3.17-cp35-abi3-win32.whl", hash = "sha256:32e764322e902bbfac49ca1446604d2839381bbbdd5a57920c9daaf2e0b778df"},
+    {file = "pycryptodomex-3.17-cp35-abi3-win_amd64.whl", hash = "sha256:4b51e826f0a04d832eda0790bbd0665d9bfe73e5a4d8ea93b6a9b38beeebe935"},
+    {file = "pycryptodomex-3.17-pp27-pypy_73-macosx_10_9_x86_64.whl", hash = "sha256:d4cf0128da167562c49b0e034f09e9cedd733997354f2314837c2fa461c87bb1"},
+    {file = "pycryptodomex-3.17-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:c92537b596bd5bffb82f8964cabb9fef1bca8a28a9e0a69ffd3ec92a4a7ad41b"},
+    {file = "pycryptodomex-3.17-pp27-pypy_73-win32.whl", hash = "sha256:599bb4ae4bbd614ca05f49bd4e672b7a250b80b13ae1238f05fd0f09d87ed80a"},
+    {file = "pycryptodomex-3.17-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4c4674f4b040321055c596aac926d12f7f6859dfe98cd12f4d9453b43ab6adc8"},
+    {file = "pycryptodomex-3.17-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67a3648025e4ddb72d43addab764336ba2e670c8377dba5dd752e42285440d31"},
+    {file = "pycryptodomex-3.17-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40e8a11f578bd0851b02719c862d55d3ee18d906c8b68a9c09f8c564d6bb5b92"},
+    {file = "pycryptodomex-3.17-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:23d83b610bd97704f0cd3acc48d99b76a15c8c1540d8665c94d514a49905bad7"},
+    {file = "pycryptodomex-3.17-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fd29d35ac80755e5c0a99d96b44fb9abbd7e871849581ea6a4cb826d24267537"},
+    {file = "pycryptodomex-3.17-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64b876d57cb894b31056ad8dd6a6ae1099b117ae07a3d39707221133490e5715"},
+    {file = "pycryptodomex-3.17-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee8bf4fdcad7d66beb744957db8717afc12d176e3fd9c5d106835133881a049b"},
+    {file = "pycryptodomex-3.17-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c84689c73358dfc23f9fdcff2cb9e7856e65e2ce3b5ed8ff630d4c9bdeb1867b"},
+    {file = "pycryptodomex-3.17.tar.gz", hash = "sha256:0af93aad8d62e810247beedef0261c148790c52f3cd33643791cc6396dd217c1"},
 ]
 pydantic = [
     {file = "pydantic-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:221166d99726238f71adc4fa9f3e94063a10787574b966f86a774559e709ac5a"},
@@ -1595,17 +1602,14 @@ pyrate-limiter = [
     {file = "pyrate-limiter-2.8.1.tar.gz", hash = "sha256:0741b7db4b3facdce60bd836e0fcc43911bc52c443f674f924afba7e02e79c18"},
 ]
 pysnmp-pyasn1 = [
-    {file = "pysnmp-pyasn1-1.1.2.tar.gz", hash = "sha256:b3345370fcb49e03ecc78b336a3f940e0c0c1409d702f64af1fe165b61e37b35"},
-    {file = "pysnmp_pyasn1-1.1.2-py3-none-any.whl", hash = "sha256:de4132bc2931a7b32277aac1ce8e7650db137199df087a376530153b1b1b4d8d"},
+    {file = "pysnmp-pyasn1-1.1.3.tar.gz", hash = "sha256:fc559133ec6717e9d96dd4bd69c981310b23364dc2280a9b5f40f684fb6b4b8a"},
+    {file = "pysnmp_pyasn1-1.1.3-py3-none-any.whl", hash = "sha256:d9a471b058adb9f2c3ce3aa85f800f2beef1a86c03b08d182a5653c9880fbd5e"},
 ]
 pysnmp-pysmi = [
     {file = "pysnmp-pysmi-1.1.10.tar.gz", hash = "sha256:0149c5772e6151f6286f546058da3e1203771d46c9b8b53b568bf1c44267506f"},
     {file = "pysnmp_pysmi-1.1.10-py3-none-any.whl", hash = "sha256:6526b2bda6ca5f01f1c0ac2c8ff01cb34e0eec3c9fe887decd86dc78121ce52c"},
 ]
-pysnmplib = [
-    {file = "pysnmplib-5.0.17-py3-none-any.whl", hash = "sha256:2400e2c7776e7653b2edac5a5d35d5aa959bd0dad54d7b06d7b95b89312d5e64"},
-    {file = "pysnmplib-5.0.17.tar.gz", hash = "sha256:73fd976f2608597776890c69a1539c9967f5ddd9ca6836cc5b0d1915e7a17ad8"},
-]
+pysnmplib = []
 pytest = [
     {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
     {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ requests-cache = "^0.9.3"
 requests-ratelimiter = "^0.2.1"
 mongoengine = "^0.24.1"
 celery-redbeat = {git = "https://github.com/splunk/redbeat", rev = "main"}
-pysnmplib = "^5.0.5"
 PyYAML = "^6.0"
 #Note this is temporary PR to upstream project is issued
 wait-for-dep = {extras = ["redis"], git="https://github.com/omrozowicz-splunk/wait-for-dep.git"}
@@ -45,6 +44,7 @@ pika = "^1.2.0"
 JSON-log-formatter ="^0.5.1"
 "ruamel.yaml" = "^0.17.21"
 mkdocs-video = "^1.3.0"
+pysnmplib = {git = "https://github.com/pysnmp/pysnmp.git", rev = "main"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -392,12 +392,23 @@ class Poller(Task):
             varbinds_bulk.add(ObjectType(ObjectIdentity("1.3.6")))
             return set(), {}, varbinds_bulk, {}
 
-        joined_profile_object = self.profiles_collection.get_profiles(profiles, walk)
+        joined_profile_object = self.profiles_collection.get_polling_info_from_profiles(
+            profiles, walk
+        )
         mib_families = joined_profile_object.get_mib_families()
-        mib_files_to_load = [mib_family for mib_family in mib_families if mib_family not in self.already_loaded_mibs]
+        mib_files_to_load = [
+            mib_family
+            for mib_family in mib_families
+            if mib_family not in self.already_loaded_mibs
+        ]
         if mib_files_to_load:
             self.load_mibs(mib_files_to_load)
-        varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = joined_profile_object.return_mapping_and_varbinds()
+        (
+            varbinds_get,
+            get_mapping,
+            varbinds_bulk,
+            bulk_mapping,
+        ) = joined_profile_object.return_mapping_and_varbinds()
         logger.debug(f"host={address} varbinds_get={varbinds_get}")
         logger.debug(f"host={address} get_mapping={get_mapping}")
         logger.debug(f"host={address} varbinds_bulk={varbinds_bulk}")

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -450,8 +450,8 @@ class Poller(Task):
                     profile = None
                     if mapping:
                         profile = mapping.get(
-                            f"{mib}:{metric}:{index_number}",
-                            mapping.get(f"{mib}:{metric}", mapping.get(mib)),
+                            id.replace('"', ''),
+                            mapping.get(f"{mib}::{metric}", mapping.get(mib)),
                         )
                     if metric_value == "No more variables left in this MIB View":
                         continue

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -450,7 +450,7 @@ class Poller(Task):
                     profile = None
                     if mapping:
                         profile = mapping.get(
-                            id.replace('"', ''),
+                            id.replace('"', ""),
                             mapping.get(f"{mib}::{metric}", mapping.get(mib)),
                         )
                     if metric_value == "No more variables left in this MIB View":

--- a/splunk_connect_for_snmp/snmp/varbinds_resolver.py
+++ b/splunk_connect_for_snmp/snmp/varbinds_resolver.py
@@ -17,8 +17,14 @@ class Varbind:
         self.object_identity = ObjectType(ObjectIdentity(*varbind_list))
 
     def mapping_key(self):
-        string_list_of_varbinds = [str(varbind) for varbind in self.list]
-        return ":".join(string_list_of_varbinds)
+        if len(self.list) == 1:
+            return self.list[0]
+        elif len(self.list) == 2:
+            return f"{self.list[0]}::{self.list[1]}"
+        else:
+            mib_prefix = f"{self.list[0]}::{self.list[1]}"
+            mib_index = ".".join(str(varbind) for varbind in self.list[2:])
+            return f"{mib_prefix}.{mib_index}"
 
     def __repr__(self):
         return f"{self.list}"
@@ -149,7 +155,6 @@ class Profile:
     def __init__(self, name, profile_dict):
         self.name = name
         self.type = profile_dict.get("condition", {}).get("type")
-        self.frequency = profile_dict.get("frequency", None)
         self.varbinds = profile_dict.get("varBinds", None)
         self.varbinds_bulk = VarBindContainer()
         self.varbinds_get = VarBindContainer()

--- a/splunk_connect_for_snmp/snmp/varbinds_resolver.py
+++ b/splunk_connect_for_snmp/snmp/varbinds_resolver.py
@@ -124,11 +124,12 @@ class VarBindContainer:
         :param varbind:
         :return:
         """
-        varbind_root, varbind_field = varbind.split(":")[:2]
+        varbind_root, varbind_field = varbind.split("::")
+        varbind_field = varbind_field.split(".")[0]
         current_varbinds = self.return_varbind_keys()
         return (
             varbind_root in current_varbinds
-            or f"{varbind_root}:{varbind_field}" in current_varbinds
+            or f"{varbind_root}::{varbind_field}" in current_varbinds
         )
 
     def __repr__(self):

--- a/splunk_connect_for_snmp/snmp/varbinds_resolver.py
+++ b/splunk_connect_for_snmp/snmp/varbinds_resolver.py
@@ -166,17 +166,14 @@ class Profile:
         if self.type == "walk":
             varbind_obj = Varbind(["SNMPv2-MIB"])
             self.varbinds_bulk.insert_varbind(varbind_obj)
+            varbind_obj = Varbind(["IF-MIB"])
+            self.varbinds_bulk.insert_varbind(varbind_obj)
         self.divide_on_bulk_and_get()
         if self.type != "walk":
             self.varbinds_bulk_mapping = self.varbinds_bulk.get_profile_mapping(
                 self.name
             )
             self.varbinds_get_mapping = self.varbinds_get.get_profile_mapping(self.name)
-        else:
-            mib_families = self.get_mib_families()
-            if "IF-MIB" not in mib_families:
-                varbind_obj = Varbind(["IF-MIB"])
-                self.varbinds_bulk.insert_varbind(varbind_obj)
 
     def divide_on_bulk_and_get(self):
         for varbind in sorted(self.varbinds, key=len):
@@ -263,7 +260,7 @@ class ProfileCollection:
             profile = self.list_of_profiles.get(profile_name)
             if not profile.varbinds and profile.type != "walk":
                 logger.warning(
-                    f"or varBinds section not present inside the profile {profile_name}"
+                    f"VarBinds section not present inside the profile {profile_name}"
                 )
                 return {}
             return self.list_of_profiles.get(profile_name)

--- a/splunk_connect_for_snmp/snmp/varbinds_resolver.py
+++ b/splunk_connect_for_snmp/snmp/varbinds_resolver.py
@@ -1,0 +1,197 @@
+from functools import reduce
+from celery.utils.log import get_task_logger
+from pysnmp.smi.rfc1902 import ObjectIdentity, ObjectType
+
+logger = get_task_logger(__name__)
+
+
+class Varbind:
+    def __init__(self, varbind_list):
+        if isinstance(varbind_list, str):
+            varbind_list = [varbind_list]
+        self.list = varbind_list
+        self.object_identity = ObjectType(ObjectIdentity(*varbind_list))
+
+    def mapping_key(self):
+        string_list_of_varbinds = [str(varbind) for varbind in self.list]
+        return ":".join(string_list_of_varbinds)
+
+    def __repr__(self):
+        return f"{self.list}"
+
+
+class VarBindContainer:
+    def __init__(self):
+        self.map = {}
+
+    def add_varbind(self, varbind):
+        mapping_key = varbind.mapping_key()
+        if mapping_key in self.map:
+            print(f"Element {mapping_key} already in the varbind container")
+            return
+        if len(varbind.list) > 1:
+            if varbind.list[0] in self.map:
+                print(
+                    f"Element {mapping_key} not added as {varbind.list[0]} is already in the varbind container"
+                )
+                return
+        if len(varbind.list) > 2:
+            varbind_tmp = Varbind(varbind.list[:2])
+            mapping_key_for_two = varbind_tmp.mapping_key()
+            if mapping_key_for_two in self.map:
+                print(
+                    f"Element {mapping_key} not added as {mapping_key_for_two} is already in the varbind container"
+                )
+                return
+        self.map[mapping_key] = varbind
+
+    def return_varbind_keys(self):
+        return list(self.map.keys())
+
+    def return_varbind_values(self):
+        return list(self.map.values())
+
+    def get_mib_families(self):
+        mib_families = []
+        for varbind in self.map.values():
+            mib_families.append(varbind.list[0])
+        return mib_families
+
+    def get_profile_mapping(self, profile_name):
+        varbind_keys = self.return_varbind_keys()
+        dict_of_keys_and_profiles = {}
+        for varbind_key in varbind_keys:
+            dict_of_keys_and_profiles[varbind_key] = profile_name
+        return dict_of_keys_and_profiles
+
+    def are_parents_in_map(self, varbind):
+        varbind_root, varbind_field = varbind.split(":")[:2]
+        current_varbinds = self.return_varbind_keys()
+        return varbind_root in current_varbinds or f"{varbind_root}:{varbind_field}" in current_varbinds
+
+    def __repr__(self):
+        return f"{self.map}"
+
+    def __add__(self, other):
+        joined_maps = {}
+        new_instance = VarBindContainer()
+        joined_maps.update(self.map)
+        joined_maps.update(other.map)
+        key_list = sorted(list(joined_maps.keys()), key=len)
+        for varbind_key in key_list:
+            new_instance.add_varbind(joined_maps.get(varbind_key))
+        return new_instance
+
+    def return_varbinds(self):
+        varbinds = []
+        for varbind in self.map:
+            varbinds += self.map[varbind]
+        return varbinds
+
+
+class Profile:
+    def __init__(self, name, profile_dict):
+        self.name = name
+        self.type = profile_dict.get("condition", {}).get("type")
+        self.frequency = profile_dict.get("frequency", None)
+        self.varbinds = profile_dict.get("varBinds", None)
+        self.varbinds_bulk = VarBindContainer()
+        self.varbinds_get = VarBindContainer()
+        self.varbinds_bulk_mapping = {}
+        self.varbinds_get_mapping = {}
+
+    def process(self):
+        if self.type == "walk":
+            varbind_obj = Varbind(["SNMPv2-MIB"])
+            self.varbinds_bulk.add_varbind(varbind_obj)
+        self.divide_on_bulk_and_get()
+        if self.type != "walk":
+            self.varbinds_bulk_mapping = self.varbinds_bulk.get_profile_mapping(self.name)
+            self.varbinds_get_mapping = self.varbinds_get.get_profile_mapping(self.name)
+        else:
+            mib_families = self.get_mib_families()
+            if "IF-MIB" not in mib_families:
+                varbind_obj = Varbind(["IF-MIB"])
+                self.varbinds_bulk.add_varbind(varbind_obj)
+
+    def divide_on_bulk_and_get(self):
+        for varbind in sorted(self.varbinds, key=len):
+            varbind_obj = Varbind(varbind)
+            if len(varbind) < 3:
+                self.varbinds_bulk.add_varbind(varbind_obj)
+            else:
+                if not self.varbinds_bulk.are_parents_in_map(varbind_obj.mapping_key()):
+                    self.varbinds_get.add_varbind(varbind_obj)
+
+    def get_varbinds(self):
+        return self.varbinds_bulk, self.varbinds_get
+
+    def get_mib_families(self):
+        return set(
+            self.varbinds_bulk.get_mib_families() + self.varbinds_get.get_mib_families()
+        )
+
+    def return_mapping_and_varbinds(self):
+        varbinds_get = [value.object_identity for value in self.varbinds_get.return_varbind_values()]
+        varbinds_bulk = [value.object_identity for value in self.varbinds_bulk.return_varbind_values()]
+        return varbinds_get, self.varbinds_get_mapping, varbinds_bulk, self.varbinds_bulk_mapping
+
+    def __add__(self, other):
+        new_instance = Profile(f"{self.name}:{other.name}", {})
+        new_instance.varbinds_bulk = self.varbinds_bulk + other.varbinds_bulk
+        new_instance.varbinds_get = self.varbinds_get + other.varbinds_get
+        new_instance.varbinds_bulk_mapping = dict(self.varbinds_bulk_mapping, **other.varbinds_bulk_mapping)
+        new_instance.varbinds_get_mapping = dict(self.varbinds_get_mapping, **other.varbinds_get_mapping)
+        return new_instance
+
+    def __repr__(self):
+        return f"Profile: {self.name}, varbinds_get: {self.varbinds_get}, varbinds_bulk: {self.varbinds_bulk}"
+
+
+class ProfileCollection:
+    def __init__(self, list_of_profiles):
+        self.list_of_profiles_raw = list_of_profiles
+        self.list_of_profiles = {}
+
+    def process_profiles(self):
+        for profile_name, profile_body in self.list_of_profiles_raw.items():
+            current_profile = Profile(profile_name, profile_body)
+            current_profile.process()
+            self.list_of_profiles[profile_name] = current_profile
+
+    def get_profiles(self, profiles_names, walk=False) -> Profile:
+        profiles = [self.get_profile(name) for name in profiles_names]
+        if len(profiles) == 1 or walk:
+            return profiles[0]
+        return reduce(self.add_profiles, profiles)
+
+    def add_profiles(self, first_profile, second_profile):
+        if isinstance(first_profile, Profile) and isinstance(second_profile, Profile):
+            return first_profile + second_profile
+        elif isinstance(first_profile, Profile):
+            return first_profile
+        elif isinstance(second_profile, Profile):
+            return second_profile
+
+    def update(self, list_of_profiles):
+        if self.list_of_profiles_raw == list_of_profiles:
+            logger.info("No change in profiles")
+        else:
+            self.list_of_profiles_raw = list_of_profiles
+            self.process_profiles()
+
+    def get_profile(self, profile_name):
+        if profile_name in self.list_of_profiles:
+            profile = self.list_of_profiles.get(profile_name)
+            if not profile.varbinds and profile.type != "walk":
+                logger.warning(
+                    f"or varBinds section not present inside the profile {profile_name}"
+                )
+                return {}
+            return self.list_of_profiles.get(profile_name)
+        else:
+            logger.warning(
+                f"There is either profile: {profile_name} missing from the configuration, or varBinds section not"
+                f"present inside the profile"
+            )
+            return {}

--- a/test/snmp/test_get_varbinds.py
+++ b/test/snmp/test_get_varbinds.py
@@ -154,8 +154,16 @@ class TestGetVarbinds(TestCase):
 
     def test_get_varbinds_for_walk_with_profiles(self):
         profiles = {
-            "profile1": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["IF-MIB"]]},
-            "profile2": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["UDP-MIB"]]},
+            "profile1": {
+                "condition": {"type": "walk"},
+                "frequency": 20,
+                "varBinds": [["IF-MIB"]],
+            },
+            "profile2": {
+                "condition": {"type": "walk"},
+                "frequency": 20,
+                "varBinds": [["UDP-MIB"]],
+            },
         }
 
         poller = Poller.__new__(Poller)
@@ -188,8 +196,16 @@ class TestGetVarbinds(TestCase):
 
     def test_get_varbinds_for_walk_with_profiles_changed_sequence(self):
         profiles = {
-            "profile1": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["IF-MIB"]]},
-            "profile2": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["UDP-MIB"]]},
+            "profile1": {
+                "condition": {"type": "walk"},
+                "frequency": 20,
+                "varBinds": [["IF-MIB"]],
+            },
+            "profile2": {
+                "condition": {"type": "walk"},
+                "frequency": 20,
+                "varBinds": [["UDP-MIB"]],
+            },
         }
 
         poller = Poller.__new__(Poller)
@@ -409,7 +425,10 @@ class TestGetVarbinds(TestCase):
 
         self.assertEqual(("IF-MIB", "ifDescr", 0), names[0])
         self.assertEqual(("IF-MIB", "ifDescr", 1), names[1])
-        self.assertEqual(("TCP-MIB", "tcpListenerProcess", 0, 443), varbinds_get[2]._ObjectType__args[0]._ObjectIdentity__args)
+        self.assertEqual(
+            ("TCP-MIB", "tcpListenerProcess", 0, 443),
+            varbinds_get[2]._ObjectType__args[0]._ObjectIdentity__args,
+        )
 
         self.assertEqual(
             {
@@ -518,5 +537,3 @@ class TestGetVarbinds(TestCase):
         self.assertEqual({"UDP-MIB:udpOutDatagrams": "profile1"}, bulk_mapping)
 
         poller.load_mibs.assert_called_with(["UDP-MIB"])
-
-

--- a/test/snmp/test_get_varbinds.py
+++ b/test/snmp/test_get_varbinds.py
@@ -317,9 +317,9 @@ class TestGetVarbinds(TestCase):
 
         self.assertEqual(
             {
-                "IF-MIB:ifDescr": "profile1",
-                "IF-MIB:ifSpeed": "profile1",
-                "UDP-MIB:udpOutDatagrams": "profile2",
+                "IF-MIB::ifDescr": "profile1",
+                "IF-MIB::ifSpeed": "profile1",
+                "UDP-MIB::udpOutDatagrams": "profile2",
             },
             bulk_mapping,
         )
@@ -373,9 +373,9 @@ class TestGetVarbinds(TestCase):
 
         self.assertEqual(
             {
-                "IF-MIB:ifDescr:0": "profile1",
-                "IF-MIB:ifDescr:1": "profile1",
-                "UDP-MIB:udpOutDatagrams:1": "profile2",
+                "IF-MIB::ifDescr.0": "profile1",
+                "IF-MIB::ifDescr.1": "profile1",
+                "UDP-MIB::udpOutDatagrams.1": "profile2",
             },
             get_mapping,
         )
@@ -432,9 +432,9 @@ class TestGetVarbinds(TestCase):
 
         self.assertEqual(
             {
-                "IF-MIB:ifDescr:0": "profile1",
-                "IF-MIB:ifDescr:1": "profile1",
-                "TCP-MIB:tcpListenerProcess:0:443": "profile2",
+                "IF-MIB::ifDescr.0": "profile1",
+                "IF-MIB::ifDescr.1": "profile1",
+                "TCP-MIB::tcpListenerProcess.0.443": "profile2",
             },
             get_mapping,
         )
@@ -534,6 +534,6 @@ class TestGetVarbinds(TestCase):
 
         self.assertEqual(("UDP-MIB", "udpOutDatagrams"), names[0])
 
-        self.assertEqual({"UDP-MIB:udpOutDatagrams": "profile1"}, bulk_mapping)
+        self.assertEqual({"UDP-MIB::udpOutDatagrams": "profile1"}, bulk_mapping)
 
         poller.load_mibs.assert_called_with(["UDP-MIB"])

--- a/test/snmp/test_get_varbinds.py
+++ b/test/snmp/test_get_varbinds.py
@@ -49,7 +49,7 @@ class TestGetVarbinds(TestCase):
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
         )
-        self.assertEqual(1, len(varbinds_get))
+        self.assertEqual(0, len(varbinds_get))
         self.assertEqual(3, len(varbinds_bulk))
         self.assertEqual(0, len(get_mapping))
         self.assertEqual(0, len(bulk_mapping))

--- a/test/snmp/test_get_varbinds.py
+++ b/test/snmp/test_get_varbinds.py
@@ -2,11 +2,15 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from splunk_connect_for_snmp.snmp.manager import Poller
+from splunk_connect_for_snmp.snmp.varbinds_resolver import ProfileCollection
 
 
 class TestGetVarbinds(TestCase):
     def test_get_varbinds_for_walk(self):
         poller = Poller.__new__(Poller)
+        poller.profiles_collection = ProfileCollection({})
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True
         )
@@ -38,11 +42,14 @@ class TestGetVarbinds(TestCase):
         }
 
         poller.profiles = profiles
+        poller.profiles_collection = ProfileCollection(profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = {}
         poller.load_mibs = Mock()
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
         )
-        self.assertEqual(0, len(varbinds_get))
+        self.assertEqual(1, len(varbinds_get))
         self.assertEqual(3, len(varbinds_bulk))
         self.assertEqual(0, len(get_mapping))
         self.assertEqual(0, len(bulk_mapping))
@@ -69,6 +76,9 @@ class TestGetVarbinds(TestCase):
         }
 
         poller.profiles = profiles
+        poller.profiles_collection = ProfileCollection(profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = {}
         poller.load_mibs = Mock()
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
@@ -99,6 +109,9 @@ class TestGetVarbinds(TestCase):
         }
 
         poller.profiles = profiles
+        poller.profiles_collection = ProfileCollection(profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = {}
         poller.load_mibs = Mock()
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
@@ -123,7 +136,7 @@ class TestGetVarbinds(TestCase):
 
     def test_get_varbinds_for_walk_next_time_no_profiles(self):
         poller = Poller.__new__(Poller)
-
+        poller.profiles_collection = ProfileCollection({})
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=[]
         )
@@ -141,12 +154,15 @@ class TestGetVarbinds(TestCase):
 
     def test_get_varbinds_for_walk_with_profiles(self):
         profiles = {
-            "profile1": {"frequency": 20, "varBinds": [["IF-MIB"]]},
-            "profile2": {"frequency": 20, "varBinds": [["UDP-MIB"]]},
+            "profile1": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["IF-MIB"]]},
+            "profile2": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["UDP-MIB"]]},
         }
 
         poller = Poller.__new__(Poller)
         poller.profiles = profiles
+        poller.profiles_collection = ProfileCollection(profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         poller.load_mibs = Mock()
 
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
@@ -172,12 +188,15 @@ class TestGetVarbinds(TestCase):
 
     def test_get_varbinds_for_walk_with_profiles_changed_sequence(self):
         profiles = {
-            "profile1": {"frequency": 20, "varBinds": [["IF-MIB"]]},
-            "profile2": {"frequency": 20, "varBinds": [["UDP-MIB"]]},
+            "profile1": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["IF-MIB"]]},
+            "profile2": {"condition": {"type": "walk"}, "frequency": 20, "varBinds": [["UDP-MIB"]]},
         }
 
         poller = Poller.__new__(Poller)
         poller.profiles = profiles
+        poller.profiles_collection = ProfileCollection(profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         poller.load_mibs = Mock()
 
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
@@ -209,6 +228,9 @@ class TestGetVarbinds(TestCase):
             "profile1": {"frequency": 20, "varBinds": [["IF-MIB"]]},
             "profile2": {"frequency": 20, "varBinds": [["UDP-MIB"]]},
         }
+        poller.profiles_collection = ProfileCollection(poller.profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         poller.load_mibs = Mock()
 
         profiles_requested = ["profile1", "profile2"]
@@ -233,7 +255,8 @@ class TestGetVarbinds(TestCase):
         self.assertEqual("IF-MIB", names[0])
         self.assertEqual("UDP-MIB", names[1])
         self.assertEqual({"IF-MIB": "profile1", "UDP-MIB": "profile2"}, bulk_mapping)
-        poller.load_mibs.assert_called_with(["IF-MIB", "UDP-MIB"])
+        poller.load_mibs.assert_called()
+        self.assertCountEqual(poller.load_mibs.call_args.args[0], ["IF-MIB", "UDP-MIB"])
 
     def test_get_varbinds_for_poll_only_bulk_properties(self):
         poller = Poller.__new__(Poller)
@@ -246,6 +269,9 @@ class TestGetVarbinds(TestCase):
             "profile2": {"frequency": 20, "varBinds": [["UDP-MIB", "udpOutDatagrams"]]},
         }
         poller.load_mibs = Mock()
+        poller.profiles_collection = ProfileCollection(poller.profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         profiles_requested = ["profile1", "profile2"]
 
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
@@ -281,7 +307,8 @@ class TestGetVarbinds(TestCase):
             },
             bulk_mapping,
         )
-        poller.load_mibs.assert_called_with(["IF-MIB", "UDP-MIB"])
+        poller.load_mibs.assert_called()
+        self.assertCountEqual(poller.load_mibs.call_args.args[0], ["IF-MIB", "UDP-MIB"])
 
     def test_get_varbinds_for_poll_only_get_properties(self):
         poller = Poller.__new__(Poller)
@@ -297,6 +324,9 @@ class TestGetVarbinds(TestCase):
             },
         }
         poller.load_mibs = Mock()
+        poller.profiles_collection = ProfileCollection(poller.profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         profiles_requested = ["profile1", "profile2"]
 
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
@@ -333,7 +363,64 @@ class TestGetVarbinds(TestCase):
             },
             get_mapping,
         )
-        poller.load_mibs.assert_called_with(["IF-MIB", "UDP-MIB"])
+        poller.load_mibs.assert_called()
+        self.assertCountEqual(poller.load_mibs.call_args.args[0], ["IF-MIB", "UDP-MIB"])
+
+    def test_get_varbinds_for_poll_only_get_properties_compound(self):
+        poller = Poller.__new__(Poller)
+
+        poller.profiles = {
+            "profile1": {
+                "frequency": 20,
+                "varBinds": [["IF-MIB", "ifDescr", 0], ["IF-MIB", "ifDescr", 1]],
+            },
+            "profile2": {
+                "frequency": 20,
+                "varBinds": [["TCP-MIB", "tcpListenerProcess", 0, 443]],
+            },
+        }
+        poller.load_mibs = Mock()
+        poller.profiles_collection = ProfileCollection(poller.profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
+        profiles_requested = ["profile1", "profile2"]
+
+        varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
+            "192.168.0.1", profiles=profiles_requested
+        )
+
+        self.assertEqual(3, len(varbinds_get))
+        self.assertEqual(0, len(varbinds_bulk))
+        self.assertEqual(3, len(get_mapping))
+        self.assertEqual(0, len(bulk_mapping))
+
+        names = sorted(
+            list(
+                map(
+                    lambda x: (
+                        x._ObjectType__args[0]._ObjectIdentity__args[0],
+                        x._ObjectType__args[0]._ObjectIdentity__args[1],
+                        x._ObjectType__args[0]._ObjectIdentity__args[2],
+                    ),
+                    varbinds_get,
+                )
+            )
+        )
+
+        self.assertEqual(("IF-MIB", "ifDescr", 0), names[0])
+        self.assertEqual(("IF-MIB", "ifDescr", 1), names[1])
+        self.assertEqual(("TCP-MIB", "tcpListenerProcess", 0, 443), varbinds_get[2]._ObjectType__args[0]._ObjectIdentity__args)
+
+        self.assertEqual(
+            {
+                "IF-MIB:ifDescr:0": "profile1",
+                "IF-MIB:ifDescr:1": "profile1",
+                "TCP-MIB:tcpListenerProcess:0:443": "profile2",
+            },
+            get_mapping,
+        )
+        poller.load_mibs.assert_called()
+        self.assertCountEqual(poller.load_mibs.call_args.args[0], ["IF-MIB", "TCP-MIB"])
 
     def test_get_varbinds_for_poll_shadowed_by_family(self):
         poller = Poller.__new__(Poller)
@@ -357,6 +444,9 @@ class TestGetVarbinds(TestCase):
             },
         }
         poller.load_mibs = Mock()
+        poller.profiles_collection = ProfileCollection(poller.profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         profiles_requested = ["profile1", "profile2"]
 
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
@@ -381,7 +471,8 @@ class TestGetVarbinds(TestCase):
         self.assertEqual("UDP-MIB", names[1])
 
         self.assertEqual({"IF-MIB": "profile2", "UDP-MIB": "profile1"}, bulk_mapping)
-        poller.load_mibs.assert_called_with(["UDP-MIB", "IF-MIB"])
+        poller.load_mibs.assert_called()
+        self.assertCountEqual(poller.load_mibs.call_args.args[0], ["IF-MIB", "UDP-MIB"])
 
     def test_get_varbinds_for_poll_shadowed_by_bulk_name(self):
         poller = Poller.__new__(Poller)
@@ -396,6 +487,9 @@ class TestGetVarbinds(TestCase):
             }
         }
         poller.load_mibs = Mock()
+        poller.profiles_collection = ProfileCollection(poller.profiles)
+        poller.profiles_collection.process_profiles()
+        poller.already_loaded_mibs = set()
         profiles_requested = ["profile1"]
 
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
@@ -424,3 +518,5 @@ class TestGetVarbinds(TestCase):
         self.assertEqual({"UDP-MIB:udpOutDatagrams": "profile1"}, bulk_mapping)
 
         poller.load_mibs.assert_called_with(["UDP-MIB"])
+
+

--- a/test/snmp/test_process_snmp_data.py
+++ b/test/snmp/test_process_snmp_data.py
@@ -285,7 +285,7 @@ class TestProcessSnmpData(TestCase):
             (var_bind_mock2_1, var_bind_mock2_2),
         ]
         metrics = {}
-        mapping = {"IF-MIB:some_metric": "profile1", "UDP-MIB:next_metric": "profile2"}
+        mapping = {"IF-MIB::some_metric": "profile1", "UDP-MIB::next_metric": "profile2"}
 
         poller.process_snmp_data(varBindTable, metrics, "some_target", mapping)
 

--- a/test/snmp/test_process_snmp_data.py
+++ b/test/snmp/test_process_snmp_data.py
@@ -285,7 +285,10 @@ class TestProcessSnmpData(TestCase):
             (var_bind_mock2_1, var_bind_mock2_2),
         ]
         metrics = {}
-        mapping = {"IF-MIB::some_metric": "profile1", "UDP-MIB::next_metric": "profile2"}
+        mapping = {
+            "IF-MIB::some_metric": "profile1",
+            "UDP-MIB::next_metric": "profile2",
+        }
 
         poller.process_snmp_data(varBindTable, metrics, "some_target", mapping)
 

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -109,7 +109,6 @@ class TestProfile(unittest.TestCase):
     def setUp(self):
         self.profile_dict = {
             "condition": {"type": "walk"},
-            "frequency": 60,
             "varBinds": [["IF-MIB", "ifInOctets", 1]],
         }
 
@@ -117,8 +116,6 @@ class TestProfile(unittest.TestCase):
         name = "test"
         profile = Profile(name, self.profile_dict)
         self.assertEqual(profile.name, name)
-        self.assertEqual(profile.type, "walk")
-        self.assertEqual(profile.frequency, 60)
         self.assertEqual(len(profile.varbinds), 1)
 
     def test_process(self):

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -127,9 +127,9 @@ class TestProfile(unittest.TestCase):
         profile = Profile("test", profile_dict)
         profile.process()
         expected_get_varbinds = VarBindContainer()
-        expected_get_varbinds.insert_varbind(Varbind(["IF-MIB", "ifOutOctets", 1]))
         expected_bulk_varbinds = VarBindContainer()
         expected_bulk_varbinds.insert_varbind(Varbind(["SNMPv2-MIB"]))
+        expected_bulk_varbinds.insert_varbind(Varbind(["IF-MIB"]))
         self.assertEqual(
             str(expected_bulk_varbinds.map), str(profile.varbinds_bulk.map)
         )

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -1,0 +1,172 @@
+import unittest
+from unittest.mock import MagicMock
+
+from pysnmp.smi.rfc1902 import ObjectType
+
+from splunk_connect_for_snmp.snmp.varbinds_resolver import Varbind, VarBindContainer, Profile
+
+
+class TestVarbind(unittest.TestCase):
+
+    def test_init_with_list(self):
+        varbind = Varbind(["SNMPv2-MIB", "sysDescr", "0"])
+        self.assertEqual(varbind.list, ["SNMPv2-MIB", "sysDescr", "0"])
+        self.assertIsInstance(varbind.object_identity, ObjectType)
+
+    def test_init_with_string(self):
+        varbind = Varbind("SNMPv2-MIB")
+        self.assertEqual(varbind.list, ["SNMPv2-MIB"])
+        self.assertIsInstance(varbind.object_identity, ObjectType)
+
+    def test_mapping_key(self):
+        varbind = Varbind(["SNMPv2-MIB", "sysDescr", "0"])
+        self.assertEqual(varbind.mapping_key(), "SNMPv2-MIB:sysDescr:0")
+
+    def test_mapping_key_multiple(self):
+        varbind = Varbind(["TCP-MIB", "tcpListenerProcess", 0, 443])
+        self.assertEqual(varbind.mapping_key(), "TCP-MIB:tcpListenerProcess:0:443")
+
+    def test_repr(self):
+        varbind = Varbind(["SNMPv2-MIB", "sysDescr", "0"])
+        self.assertEqual(repr(varbind), "['SNMPv2-MIB', 'sysDescr', '0']")
+
+
+class TestVarBindContainer(unittest.TestCase):
+    def setUp(self):
+        self.varbind_container = VarBindContainer()
+
+    def test_add_varbind(self):
+        varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
+        self.varbind_container.add_varbind(varbind1)
+        self.assertIn(varbind1.mapping_key(), self.varbind_container.map)
+
+        varbind2 = Varbind(["IP-MIB", "ipInReceives"])
+        self.varbind_container.add_varbind(varbind2)
+        self.assertIn(varbind2.mapping_key(), self.varbind_container.map)
+
+        varbind3 = Varbind(["IP-MIB", "ipInReceives", 1])
+        self.varbind_container.add_varbind(varbind3)
+        self.assertNotIn(varbind3.mapping_key(), self.varbind_container.map)
+
+        varbind4 = Varbind(["IF-MIB", "ifOutOctets"])
+        self.varbind_container.add_varbind(varbind4)
+        self.assertIn(varbind4.mapping_key(), self.varbind_container.map)
+
+    def test_return_varbind_keys(self):
+        varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
+        self.varbind_container.add_varbind(varbind1)
+        varbind2 = Varbind(["IP-MIB", "ipInReceives"])
+        self.varbind_container.add_varbind(varbind2)
+
+        varbind_keys = self.varbind_container.return_varbind_keys()
+        self.assertIn(varbind1.mapping_key(), varbind_keys)
+        self.assertIn(varbind2.mapping_key(), varbind_keys)
+        self.assertCountEqual(varbind_keys, ["IF-MIB:ifInOctets:1", "IP-MIB:ipInReceives"])
+
+    def test_return_varbind_values(self):
+        varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
+        self.varbind_container.add_varbind(varbind1)
+        varbind2 = Varbind(["IP-MIB", "ipInReceives"])
+        self.varbind_container.add_varbind(varbind2)
+
+        varbind_values = self.varbind_container.return_varbind_values()
+        self.assertIn(varbind1, varbind_values)
+        self.assertIn(varbind2, varbind_values)
+
+    def test_get_mib_families(self):
+        varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
+        self.varbind_container.add_varbind(varbind1)
+        varbind2 = Varbind(["IP-MIB", "ipInReceives"])
+        self.varbind_container.add_varbind(varbind2)
+
+        mib_families = self.varbind_container.get_mib_families()
+        self.assertIn("IF-MIB", mib_families)
+        self.assertIn("IP-MIB", mib_families)
+
+    def test_get_profile_mapping(self):
+        profile_name = "profile1"
+        varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
+        self.varbind_container.add_varbind(varbind1)
+        varbind2 = Varbind(["IP-MIB", "ipInReceives"])
+        self.varbind_container.add_varbind(varbind2)
+
+        profile_mapping = self.varbind_container.get_profile_mapping(profile_name)
+        self.assertIn(varbind1.mapping_key(), profile_mapping)
+        self.assertIn(varbind2.mapping_key(), profile_mapping)
+        self.assertEqual(len(profile_mapping), 2)
+        self.assertEqual({"IF-MIB:ifInOctets:1": "profile1", "IP-MIB:ipInReceives": "profile1"}, profile_mapping)
+
+
+class TestProfile(unittest.TestCase):
+    def setUp(self):
+        self.profile_dict = {
+            "condition": {"type": "walk"},
+            "frequency": 60,
+            "varBinds": [["IF-MIB", "ifInOctets", 1]],
+        }
+
+    def test_init(self):
+        name = "test"
+        profile = Profile(name, self.profile_dict)
+        self.assertEqual(profile.name, name)
+        self.assertEqual(profile.type, "walk")
+        self.assertEqual(profile.frequency, 60)
+        self.assertEqual(len(profile.varbinds), 1)
+
+    def test_process(self):
+        profile_dict = {
+            "frequency": 30,
+            "condition": {
+                "type": "walk"
+            },
+            "varBinds": [["IF-MIB", "ifOutOctets", 1]],
+        }
+        profile = Profile("test", profile_dict)
+        profile.process()
+        expected_get_varbinds = VarBindContainer()
+        expected_get_varbinds.add_varbind(Varbind(["IF-MIB", "ifOutOctets", 1]))
+        expected_bulk_varbinds = VarBindContainer()
+        expected_bulk_varbinds.add_varbind(Varbind(["SNMPv2-MIB"]))
+        self.assertEqual(str(expected_bulk_varbinds.map), str(profile.varbinds_bulk.map))
+        self.assertEqual(str(expected_get_varbinds.map), str(profile.varbinds_get.map))
+
+    def test_divide_on_bulk_and_get(self):
+        profile = Profile("test", self.profile_dict)
+        varbind = ["IF-MIB", "ifOutOctets", 1]
+        profile.varbinds = [varbind]
+        profile.divide_on_bulk_and_get()
+        expected_result = {"IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1])}
+        self.assertEqual(str(expected_result), str(profile.varbinds_get.map))
+
+    def test_divide_on_bulk_and_get_many_elements(self):
+        profile = Profile("test", self.profile_dict)
+        varbinds = [["IF-MIB", "ifOutOctets", 1], ["IP-MIB"], ["IP-MIB", "ipField"], ["TCP-MIB", "tcpField", 0, 1]]
+        profile.varbinds = varbinds
+        profile.divide_on_bulk_and_get()
+        expected_result_get = {"IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1]), "TCP-MIB:tcpField:0:1": Varbind(["TCP-MIB", "tcpField", 0, 1])}
+        expected_result_bulk = {"IP-MIB": Varbind(["IP-MIB"])}
+        self.assertEqual(str(expected_result_get), str(profile.varbinds_get.map))
+        self.assertEqual(str(expected_result_bulk), str(profile.varbinds_bulk.map))
+
+    def test_get_varbinds(self):
+        profile = Profile("test", self.profile_dict)
+        profile.varbinds_bulk = VarBindContainer()
+        profile.varbinds_bulk.add_varbind(Varbind(["IF-MIB"]))
+        profile.varbinds_bulk.add_varbind(Varbind(["IP-MIB", "ipField"]))
+        profile.varbinds_get = VarBindContainer()
+        profile.varbinds_get.add_varbind(Varbind(["TCP-MIB", "field1", 1]))
+        profile.varbinds_get.add_varbind(Varbind(["UDP-MIB", "fiel1d", 2]))
+        varbinds_bulk, varbinds_get = profile.get_varbinds()
+        self.assertEqual(varbinds_bulk, profile.varbinds_bulk)
+        self.assertEqual(varbinds_get, profile.varbinds_get)
+
+    def test_get_mib_families(self):
+        profile = Profile("test", self.profile_dict)
+        profile.varbinds_bulk = VarBindContainer()
+        profile.varbinds_bulk.add_varbind(Varbind(["IF-MIB"]))
+        profile.varbinds_bulk.add_varbind(Varbind(["IP-MIB", "ipField"]))
+        profile.varbinds_get = VarBindContainer()
+        profile.varbinds_get.add_varbind(Varbind(["TCP-MIB", "field1", 1]))
+        profile.varbinds_get.add_varbind(Varbind(["UDP-MIB", "fiel1d", 2]))
+        mib_families = profile.get_mib_families()
+        self.assertEqual(mib_families, {"IF-MIB", "IP-MIB", "TCP-MIB", "UDP-MIB"})

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -23,11 +23,11 @@ class TestVarbind(unittest.TestCase):
 
     def test_mapping_key(self):
         varbind = Varbind(["SNMPv2-MIB", "sysDescr", "0"])
-        self.assertEqual(varbind.mapping_key(), "SNMPv2-MIB:sysDescr:0")
+        self.assertEqual(varbind.mapping_key(), "SNMPv2-MIB::sysDescr.0")
 
     def test_mapping_key_multiple(self):
         varbind = Varbind(["TCP-MIB", "tcpListenerProcess", 0, 443])
-        self.assertEqual(varbind.mapping_key(), "TCP-MIB:tcpListenerProcess:0:443")
+        self.assertEqual(varbind.mapping_key(), "TCP-MIB::tcpListenerProcess.0.443")
 
     def test_repr(self):
         varbind = Varbind(["SNMPv2-MIB", "sysDescr", "0"])
@@ -65,7 +65,7 @@ class TestVarBindContainer(unittest.TestCase):
         self.assertIn(varbind1.mapping_key(), varbind_keys)
         self.assertIn(varbind2.mapping_key(), varbind_keys)
         self.assertCountEqual(
-            varbind_keys, ["IF-MIB:ifInOctets:1", "IP-MIB:ipInReceives"]
+            varbind_keys, ["IF-MIB::ifInOctets.1", "IP-MIB::ipInReceives"]
         )
 
     def test_return_varbind_values(self):
@@ -100,7 +100,7 @@ class TestVarBindContainer(unittest.TestCase):
         self.assertIn(varbind2.mapping_key(), profile_mapping)
         self.assertEqual(len(profile_mapping), 2)
         self.assertEqual(
-            {"IF-MIB:ifInOctets:1": "profile1", "IP-MIB:ipInReceives": "profile1"},
+            {"IF-MIB::ifInOctets.1": "profile1", "IP-MIB::ipInReceives": "profile1"},
             profile_mapping,
         )
 
@@ -144,7 +144,7 @@ class TestProfile(unittest.TestCase):
         profile.varbinds = [varbind]
         profile.divide_on_bulk_and_get()
         expected_result = {
-            "IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1])
+            "IF-MIB::ifOutOctets.1": Varbind(["IF-MIB", "ifOutOctets", 1])
         }
         self.assertEqual(str(expected_result), str(profile.varbinds_get.map))
 
@@ -159,8 +159,8 @@ class TestProfile(unittest.TestCase):
         profile.varbinds = varbinds
         profile.divide_on_bulk_and_get()
         expected_result_get = {
-            "IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1]),
-            "TCP-MIB:tcpField:0:1": Varbind(["TCP-MIB", "tcpField", 0, 1]),
+            "IF-MIB::ifOutOctets.1": Varbind(["IF-MIB", "ifOutOctets", 1]),
+            "TCP-MIB::tcpField.0.1": Varbind(["TCP-MIB", "tcpField", 0, 1]),
         }
         expected_result_bulk = {"IP-MIB": Varbind(["IP-MIB"])}
         self.assertEqual(str(expected_result_get), str(profile.varbinds_get.map))

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -3,11 +3,14 @@ from unittest.mock import MagicMock
 
 from pysnmp.smi.rfc1902 import ObjectType
 
-from splunk_connect_for_snmp.snmp.varbinds_resolver import Varbind, VarBindContainer, Profile
+from splunk_connect_for_snmp.snmp.varbinds_resolver import (
+    Profile,
+    Varbind,
+    VarBindContainer,
+)
 
 
 class TestVarbind(unittest.TestCase):
-
     def test_init_with_list(self):
         varbind = Varbind(["SNMPv2-MIB", "sysDescr", "0"])
         self.assertEqual(varbind.list, ["SNMPv2-MIB", "sysDescr", "0"])
@@ -37,37 +40,39 @@ class TestVarBindContainer(unittest.TestCase):
 
     def test_add_varbind(self):
         varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
-        self.varbind_container.add_varbind(varbind1)
+        self.varbind_container.insert_varbind(varbind1)
         self.assertIn(varbind1.mapping_key(), self.varbind_container.map)
 
         varbind2 = Varbind(["IP-MIB", "ipInReceives"])
-        self.varbind_container.add_varbind(varbind2)
+        self.varbind_container.insert_varbind(varbind2)
         self.assertIn(varbind2.mapping_key(), self.varbind_container.map)
 
         varbind3 = Varbind(["IP-MIB", "ipInReceives", 1])
-        self.varbind_container.add_varbind(varbind3)
+        self.varbind_container.insert_varbind(varbind3)
         self.assertNotIn(varbind3.mapping_key(), self.varbind_container.map)
 
         varbind4 = Varbind(["IF-MIB", "ifOutOctets"])
-        self.varbind_container.add_varbind(varbind4)
+        self.varbind_container.insert_varbind(varbind4)
         self.assertIn(varbind4.mapping_key(), self.varbind_container.map)
 
     def test_return_varbind_keys(self):
         varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
-        self.varbind_container.add_varbind(varbind1)
+        self.varbind_container.insert_varbind(varbind1)
         varbind2 = Varbind(["IP-MIB", "ipInReceives"])
-        self.varbind_container.add_varbind(varbind2)
+        self.varbind_container.insert_varbind(varbind2)
 
         varbind_keys = self.varbind_container.return_varbind_keys()
         self.assertIn(varbind1.mapping_key(), varbind_keys)
         self.assertIn(varbind2.mapping_key(), varbind_keys)
-        self.assertCountEqual(varbind_keys, ["IF-MIB:ifInOctets:1", "IP-MIB:ipInReceives"])
+        self.assertCountEqual(
+            varbind_keys, ["IF-MIB:ifInOctets:1", "IP-MIB:ipInReceives"]
+        )
 
     def test_return_varbind_values(self):
         varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
-        self.varbind_container.add_varbind(varbind1)
+        self.varbind_container.insert_varbind(varbind1)
         varbind2 = Varbind(["IP-MIB", "ipInReceives"])
-        self.varbind_container.add_varbind(varbind2)
+        self.varbind_container.insert_varbind(varbind2)
 
         varbind_values = self.varbind_container.return_varbind_values()
         self.assertIn(varbind1, varbind_values)
@@ -75,9 +80,9 @@ class TestVarBindContainer(unittest.TestCase):
 
     def test_get_mib_families(self):
         varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
-        self.varbind_container.add_varbind(varbind1)
+        self.varbind_container.insert_varbind(varbind1)
         varbind2 = Varbind(["IP-MIB", "ipInReceives"])
-        self.varbind_container.add_varbind(varbind2)
+        self.varbind_container.insert_varbind(varbind2)
 
         mib_families = self.varbind_container.get_mib_families()
         self.assertIn("IF-MIB", mib_families)
@@ -86,15 +91,18 @@ class TestVarBindContainer(unittest.TestCase):
     def test_get_profile_mapping(self):
         profile_name = "profile1"
         varbind1 = Varbind(["IF-MIB", "ifInOctets", 1])
-        self.varbind_container.add_varbind(varbind1)
+        self.varbind_container.insert_varbind(varbind1)
         varbind2 = Varbind(["IP-MIB", "ipInReceives"])
-        self.varbind_container.add_varbind(varbind2)
+        self.varbind_container.insert_varbind(varbind2)
 
         profile_mapping = self.varbind_container.get_profile_mapping(profile_name)
         self.assertIn(varbind1.mapping_key(), profile_mapping)
         self.assertIn(varbind2.mapping_key(), profile_mapping)
         self.assertEqual(len(profile_mapping), 2)
-        self.assertEqual({"IF-MIB:ifInOctets:1": "profile1", "IP-MIB:ipInReceives": "profile1"}, profile_mapping)
+        self.assertEqual(
+            {"IF-MIB:ifInOctets:1": "profile1", "IP-MIB:ipInReceives": "profile1"},
+            profile_mapping,
+        )
 
 
 class TestProfile(unittest.TestCase):
@@ -116,18 +124,18 @@ class TestProfile(unittest.TestCase):
     def test_process(self):
         profile_dict = {
             "frequency": 30,
-            "condition": {
-                "type": "walk"
-            },
+            "condition": {"type": "walk"},
             "varBinds": [["IF-MIB", "ifOutOctets", 1]],
         }
         profile = Profile("test", profile_dict)
         profile.process()
         expected_get_varbinds = VarBindContainer()
-        expected_get_varbinds.add_varbind(Varbind(["IF-MIB", "ifOutOctets", 1]))
+        expected_get_varbinds.insert_varbind(Varbind(["IF-MIB", "ifOutOctets", 1]))
         expected_bulk_varbinds = VarBindContainer()
-        expected_bulk_varbinds.add_varbind(Varbind(["SNMPv2-MIB"]))
-        self.assertEqual(str(expected_bulk_varbinds.map), str(profile.varbinds_bulk.map))
+        expected_bulk_varbinds.insert_varbind(Varbind(["SNMPv2-MIB"]))
+        self.assertEqual(
+            str(expected_bulk_varbinds.map), str(profile.varbinds_bulk.map)
+        )
         self.assertEqual(str(expected_get_varbinds.map), str(profile.varbinds_get.map))
 
     def test_divide_on_bulk_and_get(self):
@@ -135,15 +143,25 @@ class TestProfile(unittest.TestCase):
         varbind = ["IF-MIB", "ifOutOctets", 1]
         profile.varbinds = [varbind]
         profile.divide_on_bulk_and_get()
-        expected_result = {"IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1])}
+        expected_result = {
+            "IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1])
+        }
         self.assertEqual(str(expected_result), str(profile.varbinds_get.map))
 
     def test_divide_on_bulk_and_get_many_elements(self):
         profile = Profile("test", self.profile_dict)
-        varbinds = [["IF-MIB", "ifOutOctets", 1], ["IP-MIB"], ["IP-MIB", "ipField"], ["TCP-MIB", "tcpField", 0, 1]]
+        varbinds = [
+            ["IF-MIB", "ifOutOctets", 1],
+            ["IP-MIB"],
+            ["IP-MIB", "ipField"],
+            ["TCP-MIB", "tcpField", 0, 1],
+        ]
         profile.varbinds = varbinds
         profile.divide_on_bulk_and_get()
-        expected_result_get = {"IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1]), "TCP-MIB:tcpField:0:1": Varbind(["TCP-MIB", "tcpField", 0, 1])}
+        expected_result_get = {
+            "IF-MIB:ifOutOctets:1": Varbind(["IF-MIB", "ifOutOctets", 1]),
+            "TCP-MIB:tcpField:0:1": Varbind(["TCP-MIB", "tcpField", 0, 1]),
+        }
         expected_result_bulk = {"IP-MIB": Varbind(["IP-MIB"])}
         self.assertEqual(str(expected_result_get), str(profile.varbinds_get.map))
         self.assertEqual(str(expected_result_bulk), str(profile.varbinds_bulk.map))
@@ -151,11 +169,11 @@ class TestProfile(unittest.TestCase):
     def test_get_varbinds(self):
         profile = Profile("test", self.profile_dict)
         profile.varbinds_bulk = VarBindContainer()
-        profile.varbinds_bulk.add_varbind(Varbind(["IF-MIB"]))
-        profile.varbinds_bulk.add_varbind(Varbind(["IP-MIB", "ipField"]))
+        profile.varbinds_bulk.insert_varbind(Varbind(["IF-MIB"]))
+        profile.varbinds_bulk.insert_varbind(Varbind(["IP-MIB", "ipField"]))
         profile.varbinds_get = VarBindContainer()
-        profile.varbinds_get.add_varbind(Varbind(["TCP-MIB", "field1", 1]))
-        profile.varbinds_get.add_varbind(Varbind(["UDP-MIB", "fiel1d", 2]))
+        profile.varbinds_get.insert_varbind(Varbind(["TCP-MIB", "field1", 1]))
+        profile.varbinds_get.insert_varbind(Varbind(["UDP-MIB", "fiel1d", 2]))
         varbinds_bulk, varbinds_get = profile.get_varbinds()
         self.assertEqual(varbinds_bulk, profile.varbinds_bulk)
         self.assertEqual(varbinds_get, profile.varbinds_get)
@@ -163,10 +181,10 @@ class TestProfile(unittest.TestCase):
     def test_get_mib_families(self):
         profile = Profile("test", self.profile_dict)
         profile.varbinds_bulk = VarBindContainer()
-        profile.varbinds_bulk.add_varbind(Varbind(["IF-MIB"]))
-        profile.varbinds_bulk.add_varbind(Varbind(["IP-MIB", "ipField"]))
+        profile.varbinds_bulk.insert_varbind(Varbind(["IF-MIB"]))
+        profile.varbinds_bulk.insert_varbind(Varbind(["IP-MIB", "ipField"]))
         profile.varbinds_get = VarBindContainer()
-        profile.varbinds_get.add_varbind(Varbind(["TCP-MIB", "field1", 1]))
-        profile.varbinds_get.add_varbind(Varbind(["UDP-MIB", "fiel1d", 2]))
+        profile.varbinds_get.insert_varbind(Varbind(["TCP-MIB", "field1", 1]))
+        profile.varbinds_get.insert_varbind(Varbind(["UDP-MIB", "fiel1d", 2]))
         mib_families = profile.get_mib_families()
         self.assertEqual(mib_families, {"IF-MIB", "IP-MIB", "TCP-MIB", "UDP-MIB"})


### PR DESCRIPTION
# Description

This PR makes it possible to allow using compound indexes in SC4SNMP.
So far, there was only a way to specify one index in polling, like:
- ["IF-MIB", "ifInOctets", 1"]

Now, we can use complex indexes as well:
- ['IP-MIB', 'ipAddressStatus', 'ipv4', '172.31.27.144']


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement
- [x] This change requires a documentation update

## How Has This Been Tested?

Manual tests, unit tests, integration tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings