### PR TITLE
fix: do not poll IF-MIB by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - add option to automatically poll SNMP objects based on provided conditions with conditional profiles
+- remove IF-MIB from the scope of the default small walk
 
 ## [1.8.6]
 

--- a/charts/splunk-connect-for-snmp/templates/NOTES.txt
+++ b/charts/splunk-connect-for-snmp/templates/NOTES.txt
@@ -1,9 +1,2 @@
-Version 1.7 of SC4SNMP add new feature which enables horizontal worker pods autoscaling, in order to use it you will need to turn on microk8s metrics-server addon:
-
-microk8s enable metrics-server
-
-and you should also update worker configuration in values.yaml file according to the documentation:
-https://splunk.github.io/splunk-connect-for-snmp/main/configuration/worker-configuration
-
-values.yaml template is available here:
-https://splunk.github.io/splunk-connect-for-snmp/main/gettingstarted/sc4snmp-installation
+Walk profiles no longer include IF-MIB family by default.
+If you've used this functionality before, please update the walk profile with ['IF-MIB'] varBind.

--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -93,6 +93,8 @@ Common labels
   value: {{ .Values.worker.walkRetryMaxInterval | default "600" | quote }}
 - name: METRICS_INDEXING_ENABLED
   value: {{ (.Values.poller).metricsIndexingEnabled | default "false" | quote }}
+- name: POLL_BASE_PROFILES
+  value: {{ (.Values.poller).pollBaseProfiles | quote }}
 {{- if .Values.worker.ignoreNotIncreasingOid }}
 - name: IGNORE_NOT_INCREASING_OIDS
   value: {{ join "," .Values.worker.ignoreNotIncreasingOid }}

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -141,6 +141,10 @@ poller:
   # https://splunk.github.io/splunk-connect-for-snmp/main/configuration/poller-configuration/#append-oid-index-part-to-the-metrics
   metricsIndexingEnabled: false
 
+  # Enable polling base profiles (with IF-MIB and SNMPv2-MIB) from
+  # https://github:com/splunk/splunk-connect-for-snmp/blob/main/splunk_connect_for_snmp/profiles/base.yaml
+  pollBaseProfiles: true
+
   # list of kubernetes secrets name that will be used for polling
   # https://splunk.github.io/splunk-connect-for-snmp/main/configuration/poller-configuration/#define-usernamesecrets
   usernameSecrets: []

--- a/docs/configuration/configuring-profiles.md
+++ b/docs/configuration/configuring-profiles.md
@@ -160,8 +160,8 @@ poller:
 ```
 
 NOTE: When small walk is configured, you can set up polling only of OIDs belonging to the walk profile varBinds. 
-Additionally, there are two MIB families that are enabled by default (we need them to create the state of the device in the database and poll base profiles): `IF-MIB` and `SNMPv2-MIB`.
-For example, if you've decided to use `small_walk` from the example above, you'll be able to poll only `UDP-MIB`, `IF-MIB`, and `SNMPv2-MIB` OIDs.
+Additionally, `SNMPv2-MIB` that is enabled by default (we need it to create the state of the device in the database).
+For example, if you've decided to use `small_walk` from the example above, you'll be able to poll only `UDP-MIB`, and `SNMPv2-MIB` OIDs.
 
 
 ## SmartProfile configuration

--- a/docs/configuration/poller-configuration.md
+++ b/docs/configuration/poller-configuration.md
@@ -66,6 +66,26 @@ out of this object:
 }
 ```
 
+Not every SNMP metric object is structured the way it has its index as a one of the field value.
+We can append the index part of OID with:
+
+```yaml
+poller:
+  metricsIndexingEnabled: true
+```
+
+
+### Disable automatic polling of base profiles
+
+There are [two profiles](https://github:com/splunk/splunk-connect-for-snmp/blob/main/splunk_connect_for_snmp/profiles/base.yaml) that are being polled by default - so that even without any configuration you can see
+the data in Splunk. You can disable it with `pollBaseProfiles` parameter.
+
+```yaml
+poller:
+  pollBaseProfiles: false
+```
+
+
 ### Configure inventory 
 To update inventory, see: [Update Inventory and Profile](#update-inventory).
 

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/common/scheduler-config.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/common/scheduler-config.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |-

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 data:
   inventory.csv: |

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/common/traps-config.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/common/traps-config.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |-

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-inventory
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   ttlSecondsAfterFinished: 300
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: splunk-connect-for-snmp-inventory
-          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.6"
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.7-beta.3"
           imagePullPolicy: Always
           args:
               ["inventory"]

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 10001
             runAsGroup: 10001
-          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.6"
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.7-beta.3"
           imagePullPolicy: Always
           args:
             [

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/pdb.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/pdb.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 1

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/serviceaccount.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/serviceaccount.yaml
@@ -5,6 +5,6 @@ kind: ServiceAccount
 metadata:
   name: release-name-splunk-connect-for-snmp-user
   labels:
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/sim/pdb.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/sim/pdb.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-sim
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 80%

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -5,8 +5,8 @@ kind: Pod
 metadata:
   name: "release-name-splunk-connect-for-snmp-trap-test-connection"
   labels:
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-trap
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 2
@@ -35,7 +35,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 10001
             runAsGroup: 10001
-          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.6"
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.7-beta.3"
           imagePullPolicy: Always
           args:
             [

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/pdb.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/pdb.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-trap
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 80%

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-trap
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     metallb.universe.tf/allow-shared-ip: "splunk-connect"

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/pdb.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/pdb.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-worker
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 80%

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 2
@@ -35,7 +35,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 10001
             runAsGroup: 10001
-          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.6"
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.7-beta.3"
           imagePullPolicy: Always
           args:
             [
@@ -47,7 +47,7 @@ spec:
             - name: REDIS_URL
               value: redis://release-name-redis-headless:6379/1
             - name: SC4SNMP_VERSION
-              value: 1.8.6
+              value: 1.8.7-beta.3
             - name: CELERY_BROKER_URL
               value: redis://release-name-redis-headless:6379/0
             - name: MONGO_URI
@@ -56,6 +56,8 @@ spec:
               value: "60"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
+            - name: POLL_BASE_PROFILES
+              value: "true"
             - name: LOG_LEVEL
               value: INFO
             - name: UDP_CONNECTION_TIMEOUT

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 10001
             runAsGroup: 10001
-          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.6"
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.7-beta.3"
           imagePullPolicy: Always
           args:
             [
@@ -47,7 +47,7 @@ spec:
             - name: REDIS_URL
               value: redis://release-name-redis-headless:6379/1
             - name: SC4SNMP_VERSION
-              value: 1.8.6
+              value: 1.8.7-beta.3
             - name: CELERY_BROKER_URL
               value: redis://release-name-redis-headless:6379/0
             - name: MONGO_URI
@@ -56,6 +56,8 @@ spec:
               value: "60"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
+            - name: POLL_BASE_PROFILES
+              value: "true"
             - name: LOG_LEVEL
               value: INFO
             - name: UDP_CONNECTION_TIMEOUT

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
     app.kubernetes.io/instance: release-name
-    helm.sh/chart: splunk-connect-for-snmp-1.8.6
-    app.kubernetes.io/version: "1.8.6"
+    helm.sh/chart: splunk-connect-for-snmp-1.8.7-beta.3
+    app.kubernetes.io/version: "1.8.7-beta.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 2
@@ -35,7 +35,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 10001
             runAsGroup: 10001
-          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.6"
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:1.8.7-beta.3"
           imagePullPolicy: Always
           args:
             [
@@ -47,7 +47,7 @@ spec:
             - name: REDIS_URL
               value: redis://release-name-redis-headless:6379/1
             - name: SC4SNMP_VERSION
-              value: 1.8.6
+              value: 1.8.7-beta.3
             - name: CELERY_BROKER_URL
               value: redis://release-name-redis-headless:6379/0
             - name: MONGO_URI
@@ -56,6 +56,8 @@ spec:
               value: "60"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
+            - name: POLL_BASE_PROFILES
+              value: "true"
             - name: LOG_LEVEL
               value: INFO
             - name: UDP_CONNECTION_TIMEOUT

--- a/splunk_connect_for_snmp/inventory/tasks.py
+++ b/splunk_connect_for_snmp/inventory/tasks.py
@@ -48,6 +48,7 @@ MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 CONFIG_PATH = os.getenv("CONFIG_PATH", "/app/config/config.yaml")
 PROFILES_RELOAD_DELAY = int(os.getenv("PROFILES_RELOAD_DELAY", "300"))
+POLL_BASE_PROFILES = human_bool(os.getenv("POLL_BASE_PROFILES", "true"))
 
 
 class BadlyFormattedFieldError(Exception):
@@ -150,7 +151,7 @@ def assign_profiles(ir, profiles, target):
                 continue
 
             # skip this profile it is static
-            if profile["condition"]["type"] == "base":
+            if profile["condition"]["type"] == "base" and POLL_BASE_PROFILES:
                 logger.debug(f"Adding base profile {profile_name}")
                 add_profile_to_assigned_list(
                     assigned_profiles, profile["frequency"], profile_name

--- a/splunk_connect_for_snmp/profiles/base.yaml
+++ b/splunk_connect_for_snmp/profiles/base.yaml
@@ -13,13 +13,13 @@ BaseDeviceData:
   condition:
     type: "mandatory"
   varBinds:
-    # Syntax: [ "MIB-Files", "MIB ocelery[tblib]bject name" "MIB index number"]
+    # Syntax: [ "MIB-Files", "MIB object name" "MIB index number"]
     - ["SNMPv2-MIB", "sysDescr",0]
     - ["SNMPv2-MIB", "sysName",0]
     - ["SNMPv2-MIB", "sysObjectID",0]
     - ["SNMPv2-MIB", "sysContact",0]
     - ["SNMPv2-MIB", "sysLocation",0]
-EnirchIF:
+EnrichIF:
   frequency: 600
   condition:
     type: "base"

--- a/splunk_connect_for_snmp/snmp/varbinds_resolver.py
+++ b/splunk_connect_for_snmp/snmp/varbinds_resolver.py
@@ -66,9 +66,9 @@ class VarBindContainer:
     def return_varbind_keys(self) -> List[str]:
         """
         Returns all keys from the map. When the map is:
-        {'IF-MIB:ifOutOctets': ['IF-MIB', 'ifOutOctets'],
-         'IF-MIB:ifInOctets': ['IF-MIB', 'ifInOctets'],
-         'TCP-MIB:tcpOutRsts': ['TCP-MIB', 'tcpOutRsts']}
+        {'IF-MIB::ifOutOctets': ['IF-MIB', 'ifOutOctets'],
+         'IF-MIB::ifInOctets': ['IF-MIB', 'ifInOctets'],
+         'TCP-MIB::tcpOutRsts': ['TCP-MIB', 'tcpOutRsts']}
 
          It will return ['IF-MIB:ifOutOctets', 'IF-MIB:ifInOctets', 'TCP-MIB:tcpOutRsts']
         :return:
@@ -78,9 +78,9 @@ class VarBindContainer:
     def return_varbind_values(self) -> List[Varbind]:
         """
         Returns all values from the map. When the map is:
-        {'IF-MIB:ifOutOctets': ['IF-MIB', 'ifOutOctets'],
-         'IF-MIB:ifInOctets': ['IF-MIB', 'ifInOctets'],
-         'TCP-MIB:tcpOutRsts': ['TCP-MIB', 'tcpOutRsts']}
+        {'IF-MIB::ifOutOctets': ['IF-MIB', 'ifOutOctets'],
+         'IF-MIB::ifInOctets': ['IF-MIB', 'ifInOctets'],
+         'TCP-MIB::tcpOutRsts': ['TCP-MIB', 'tcpOutRsts']}
 
          It will return [['IF-MIB', 'ifOutOctets'], ['IF-MIB', 'ifInOctets'], ['TCP-MIB', 'tcpOutRsts']]
          Remember, ['IF-MIB', 'ifOutOctets'] objects represent Varbind structures.
@@ -91,9 +91,9 @@ class VarBindContainer:
     def get_mib_families(self):
         """
         Gathers all MIB families to load it from mibserver whenever they're missing. When the map is:
-        {'IF-MIB:ifOutOctets': ['IF-MIB', 'ifOutOctets'],
-         'IF-MIB:ifInOctets': ['IF-MIB', 'ifInOctets'],
-         'TCP-MIB:tcpOutRsts': ['TCP-MIB', 'tcpOutRsts']}
+        {'IF-MIB::ifOutOctets': ['IF-MIB', 'ifOutOctets'],
+         'IF-MIB::ifInOctets': ['IF-MIB', 'ifInOctets'],
+         'TCP-MIB::tcpOutRsts': ['TCP-MIB', 'tcpOutRsts']}
 
          It will return ['IF-MIB, 'TCP-MIB']
         :return:
@@ -165,8 +165,6 @@ class Profile:
     def process(self):
         if self.type == "walk":
             varbind_obj = Varbind(["SNMPv2-MIB"])
-            self.varbinds_bulk.insert_varbind(varbind_obj)
-            varbind_obj = Varbind(["IF-MIB"])
             self.varbinds_bulk.insert_varbind(varbind_obj)
         self.divide_on_bulk_and_get()
         if self.type != "walk":

--- a/test/common/base_profiles/base.yaml
+++ b/test/common/base_profiles/base.yaml
@@ -6,7 +6,7 @@ BaseUpTime:
     - [ "IF-MIB", "ifName" ]
     - [ "IF-MIB", "ifAlias" ]
     - ["SNMPv2-MIB", "sysUpTime", 0]
-EnirchIF:
+EnrichIF:
   frequency: 600
   condition:
     type: "base"

--- a/test/common/base_profiles/runtime_config_enabled.yaml
+++ b/test/common/base_profiles/runtime_config_enabled.yaml
@@ -1,7 +1,7 @@
 profiles:
   BaseUpTime:
     enabled: false
-  EnirchIF:
+  EnrichIF:
     frequency: 200
     condition:
       type: "base"

--- a/test/common/test_profiles.py
+++ b/test/common/test_profiles.py
@@ -96,7 +96,7 @@ class TestProfiles(TestCase):
                     ["SNMPv2-MIB", "sysUpTime", 0],
                 ],
             },
-            "EnirchIF": {
+            "EnrichIF": {
                 "frequency": 600,
                 "condition": {"type": "base"},
                 "varBinds": [
@@ -162,7 +162,7 @@ class TestProfiles(TestCase):
                     ["SNMPv2-MIB", "sysUpTime", 0],
                 ],
             },
-            "EnirchIF": {
+            "EnrichIF": {
                 "frequency": 600,
                 "condition": {"type": "base"},
                 "varBinds": [
@@ -206,7 +206,7 @@ class TestProfiles(TestCase):
     )
     def test_disabled_profiles(self):
         active_profiles = {
-            "EnirchIF": {
+            "EnrichIF": {
                 "frequency": 200,
                 "condition": {"type": "base"},
                 "varBinds": [

--- a/test/inventory/test_assign_profiles.py
+++ b/test/inventory/test_assign_profiles.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase, mock
 
 from splunk_connect_for_snmp.common.inventory_record import InventoryRecord
@@ -70,6 +71,18 @@ class TestProfilesAssignment(TestCase):
 
         result, _ = assign_profiles(ir_smart, profiles, {})
         self.assertEqual({60: ["BaseUpTime"], 30: ["profile2"]}, result)
+
+    @mock.patch.dict(os.environ, {"POLL_BASE_PROFILES": "false"})
+    def test_assignment_of_base_profiles_polling_disabled(self, return_all_profiles):
+        from splunk_connect_for_snmp.inventory.tasks import assign_profiles
+
+        profiles = {
+            "BaseUpTime": {"frequency": 60, "condition": {"type": "base"}},
+            "profile2": {"frequency": 30, "condition": {"type": "base"}},
+        }
+
+        result, _ = assign_profiles(ir_smart, profiles, {})
+        self.assertEqual({}, result)
 
     def test_assignment_of_field_profiles(self, return_all_profiles):
         from splunk_connect_for_snmp.inventory.tasks import assign_profiles

--- a/test/inventory/test_assign_profiles.py
+++ b/test/inventory/test_assign_profiles.py
@@ -72,7 +72,7 @@ class TestProfilesAssignment(TestCase):
         result, _ = assign_profiles(ir_smart, profiles, {})
         self.assertEqual({60: ["BaseUpTime"], 30: ["profile2"]}, result)
 
-    @mock.patch.dict(os.environ, {"POLL_BASE_PROFILES": "false"})
+    @mock.patch("splunk_connect_for_snmp.inventory.tasks.POLL_BASE_PROFILES", False)
     def test_assignment_of_base_profiles_polling_disabled(self, return_all_profiles):
         from splunk_connect_for_snmp.inventory.tasks import assign_profiles
 

--- a/test/snmp/test_get_varbinds.py
+++ b/test/snmp/test_get_varbinds.py
@@ -49,7 +49,7 @@ class TestGetVarbinds(TestCase):
         varbinds_get, get_mapping, varbinds_bulk, bulk_mapping = poller.get_var_binds(
             "192.168.0.1", walk=True, profiles=["test1"]
         )
-        self.assertEqual(0, len(varbinds_get))
+        self.assertEqual(1, len(varbinds_get))
         self.assertEqual(3, len(varbinds_bulk))
         self.assertEqual(0, len(get_mapping))
         self.assertEqual(0, len(bulk_mapping))
@@ -84,7 +84,7 @@ class TestGetVarbinds(TestCase):
             "192.168.0.1", walk=True, profiles=["test1"]
         )
         self.assertEqual(0, len(varbinds_get))
-        self.assertEqual(2, len(varbinds_bulk))
+        self.assertEqual(1, len(varbinds_bulk))
         self.assertEqual(0, len(get_mapping))
         self.assertEqual(0, len(bulk_mapping))
 
@@ -93,9 +93,8 @@ class TestGetVarbinds(TestCase):
         self.assertEqual(
             {
                 walk_var_bind[0]._ObjectType__args[0]._ObjectIdentity__args[0],
-                walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0],
             },
-            {"SNMPv2-MIB", "IF-MIB"},
+            {"SNMPv2-MIB"},
         )
 
     def test_get_varbinds_for_walk_with_three_profiles(self):
@@ -117,7 +116,7 @@ class TestGetVarbinds(TestCase):
             "192.168.0.1", walk=True, profiles=["test1"]
         )
         self.assertEqual(0, len(varbinds_get))
-        self.assertEqual(5, len(varbinds_bulk))
+        self.assertEqual(4, len(varbinds_bulk))
         self.assertEqual(0, len(get_mapping))
         self.assertEqual(0, len(bulk_mapping))
 
@@ -129,9 +128,8 @@ class TestGetVarbinds(TestCase):
                 walk_var_bind[1]._ObjectType__args[0]._ObjectIdentity__args[0],
                 walk_var_bind[2]._ObjectType__args[0]._ObjectIdentity__args[0],
                 walk_var_bind[3]._ObjectType__args[0]._ObjectIdentity__args[0],
-                walk_var_bind[4]._ObjectType__args[0]._ObjectIdentity__args[0],
             },
-            {"SNMPv2-MIB", "IF-MIB", "UDP-MIB", "IP-MIB", "TCP-MIB"},
+            {"SNMPv2-MIB", "UDP-MIB", "IP-MIB", "TCP-MIB"},
         )
 
     def test_get_varbinds_for_walk_next_time_no_profiles(self):
@@ -220,7 +218,7 @@ class TestGetVarbinds(TestCase):
         )
 
         self.assertEqual(0, len(varbinds_get))
-        self.assertEqual(3, len(varbinds_bulk))
+        self.assertEqual(2, len(varbinds_bulk))
         self.assertEqual(0, len(get_mapping))
         self.assertEqual(0, len(bulk_mapping))
 
@@ -233,9 +231,8 @@ class TestGetVarbinds(TestCase):
             )
         )
 
-        self.assertEqual("IF-MIB", names[0])
-        self.assertEqual("SNMPv2-MIB", names[1])
-        self.assertEqual("UDP-MIB", names[2])
+        self.assertEqual("SNMPv2-MIB", names[0])
+        self.assertEqual("UDP-MIB", names[1])
 
     def test_get_varbinds_for_poll_family_only(self):
         poller = Poller.__new__(Poller)

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -129,7 +129,7 @@ class TestProfile(unittest.TestCase):
         expected_get_varbinds = VarBindContainer()
         expected_bulk_varbinds = VarBindContainer()
         expected_bulk_varbinds.insert_varbind(Varbind(["SNMPv2-MIB"]))
-        expected_bulk_varbinds.insert_varbind(Varbind(["IF-MIB"]))
+        expected_get_varbinds.insert_varbind(Varbind(["IF-MIB", "ifOutOctets", 1]))
         self.assertEqual(
             str(expected_bulk_varbinds.map), str(profile.varbinds_bulk.map)
         )


### PR DESCRIPTION
# Description

This PR limits the default small walk to not include `IF-MIB` family as this is not what we always want to poll from the devices.
Additionally it adds a way to stop polling base profiles as not everyone need them.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings