### PR TITLE
fix: treating not existing group name as a hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - add option to automatically poll SNMP objects based on provided conditions with conditional profiles
 - remove IF-MIB from the scope of the default small walk
 
+### Fixed
+- possibility to use hostname instead of the bare ip address in polling
+
 ## [1.8.6]
 
 ### Changed

--- a/splunk_connect_for_snmp/common/inventory_processor.py
+++ b/splunk_connect_for_snmp/common/inventory_processor.py
@@ -139,8 +139,9 @@ class InventoryProcessor:
                 self.inventory_records.append(host_group_object)
         else:
             self.logger.warning(
-                f"Group {group_name} doesn't exist in the configuration. Skipping..."
+                f"Group {group_name} doesn't exist in the configuration. Treating {group_name} as a hostname"
             )
+            self.single_hosts.append(source_object)
 
 
 class InventoryRecordManager:

--- a/test/common/test_inventory_processor.py
+++ b/test/common/test_inventory_processor.py
@@ -189,11 +189,11 @@ class TestInventoryProcessor(TestCase):
             inventory_processor.inventory_records, group_object_returned
         )
 
-    def test_get_group_hosts_no_group_found(self):
+    def test_get_group_hosts_hostname(self):
         group_manager = Mock()
         logger = Mock()
         group_object = {
-            "address": "group1",
+            "address": "ec2-54-91-99-115.compute-1.amazonaws.com",
             "port": "",
             "version": "2c",
             "community": "public",
@@ -206,10 +206,14 @@ class TestInventoryProcessor(TestCase):
         }
         inventory_processor = InventoryProcessor(group_manager, logger)
         group_manager.return_element.return_value = []
-        inventory_processor.get_group_hosts(group_object, "group1")
-        logger.warning.assert_called_with(
-            "Group group1 doesn't exist in the configuration. Skipping..."
+        inventory_processor.get_group_hosts(
+            group_object, "ec2-54-91-99-115.compute-1.amazonaws.com"
         )
+        logger.warning.assert_called_with(
+            "Group ec2-54-91-99-115.compute-1.amazonaws.com doesn't exist in the configuration. Treating ec2-54-91-99-115.compute-1.amazonaws.com as a hostname"
+        )
+        self.assertEqual(inventory_processor.single_hosts, [group_object])
+        self.assertEqual(inventory_processor.inventory_records, [])
 
     def test_process_line_comment(self):
         logger = Mock()


### PR DESCRIPTION
# Description

This change will fix skipping non existing group - instead we will treat this group automatically as a hostname.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Unit tests, manual tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings