### PR TITLE
chore:  bump certifi from 2022.12.7 to 2023.7.22

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -157,13 +157,13 @@ resolved_reference = "c9998348471e561ffa584ea7f72e097e96c08752"
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]
@@ -1893,4 +1893,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c177ca110a8dabab70e073946f58d516c6b505f935ab5ab013fe189b250c10f6"
+content-hash = "0a25b11b18d4b918c06adc0ba3eb0a13beb1f57de815464d2d9f34369efdee6a"


### PR DESCRIPTION
# Description

Bumps [certifi](https://github.com/certifi/python-certifi) from 2022.12.7 to 2023.7.22.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

N/A

## How Has This Been Tested?

N/A

## Checklist

N/A