### PR TITLE
fix: while configuring host inside the group without explicitly specifying its port, and later adding explicite port, the previous configuration with the default port from the inventory will be deleted

### DIFF
--- a/splunk_connect_for_snmp/inventory/loader.py
+++ b/splunk_connect_for_snmp/inventory/loader.py
@@ -89,11 +89,11 @@ def load():
         mongo_client, periodic_obj, logger
     )
     logger.info(f"Loading inventory from {INVENTORY_PATH}")
-    inventory_lines = inventory_processor.get_all_hosts()
+    inventory_lines, inventory_group_port_mapping = inventory_processor.get_all_hosts()
 
     # Function to delete inventory records that are
     hosts_from_groups_to_delete = return_hosts_from_deleted_groups(
-        previous_groups, new_groups
+        previous_groups, new_groups, inventory_group_port_mapping
     )
     for host in hosts_from_groups_to_delete:
         inventory_record_manager.delete(host)

--- a/test/common/test_inventory_processor.py
+++ b/test/common/test_inventory_processor.py
@@ -72,7 +72,11 @@ class TestInventoryProcessor(TestCase):
         }
 
         self.assertEqual(
-            return_hosts_from_deleted_groups(previous_groups, new_groups),
+            return_hosts_from_deleted_groups(
+                previous_groups,
+                new_groups,
+                {"group1": {"port": 161}, "switches": {"port": 161}},
+            ),
             ["1.1.1.1:162"],
         )
 
@@ -95,7 +99,11 @@ class TestInventoryProcessor(TestCase):
         }
 
         self.assertEqual(
-            return_hosts_from_deleted_groups(previous_groups, new_groups),
+            return_hosts_from_deleted_groups(
+                previous_groups,
+                new_groups,
+                {"group1": 161, "switches": 161},
+            ),
             ["12.22.23.33", "1.1.1.1:162"],
         )
 
@@ -115,7 +123,11 @@ class TestInventoryProcessor(TestCase):
         }
 
         self.assertEqual(
-            return_hosts_from_deleted_groups(previous_groups, new_groups),
+            return_hosts_from_deleted_groups(
+                previous_groups,
+                new_groups,
+                {"group1": 161, "switches": 161},
+            ),
             ["123.0.0.1", "178.8.8.1:999", "1.1.1.1:162"],
         )
 
@@ -123,14 +135,37 @@ class TestInventoryProcessor(TestCase):
         previous_groups = {}
         new_groups = {}
         self.assertEqual(
-            return_hosts_from_deleted_groups(previous_groups, new_groups), []
+            return_hosts_from_deleted_groups(previous_groups, new_groups, {}), []
         )
 
     def test_return_hosts_new_ones(self):
         previous_groups = {}
         new_groups = {"switches": [{"address": "12.22.23.33", "port": 161}]}
         self.assertEqual(
-            return_hosts_from_deleted_groups(previous_groups, new_groups), []
+            return_hosts_from_deleted_groups(
+                previous_groups, new_groups, {"switches": {"port": 161}}
+            ),
+            [],
+        )
+
+    def test_return_deleted_host_without_port_config(self):
+        previous_groups = {
+            "group1": [
+                {"address": "123.0.0.1", "port": 161},
+                {"address": "178.8.8.1"},
+            ]
+        }
+        new_groups = {
+            "group1": [
+                {"address": "123.0.0.1", "port": 161},
+                {"address": "178.8.8.1", "port": 162},
+            ]
+        }
+        self.assertEqual(
+            ["178.8.8.1:1161"],
+            return_hosts_from_deleted_groups(
+                previous_groups, new_groups, {"group1": 1161}
+            ),
         )
 
     def test_get_group_hosts(self):


### PR DESCRIPTION
# Description

While configuring host inside the group without explicitly specifying its port, and later adding explicite port, the previous configuration with the default port from the inventory will be deleted

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added and updated existing unit tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings