### PR TITLE
fix: make walk max retries parameter configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - add regex and option to negate conditional profiles search
 - downgrade of some log messages from warning to info
 - upgrade of pymongo to v4
+- make max walk retries configurable and decrease it from 50 to 5 by default to not waste time and resources on 
+continuously ask devices that does not respond
 
 ### Fixed
 - empty profile name when MIB family name and a polled varbind differs

--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -90,7 +90,9 @@ Common labels
 - name: MONGO_URI
   value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
 - name: WALK_RETRY_MAX_INTERVAL
-  value: {{ .Values.worker.walkRetryMaxInterval | default "600" | quote }}
+  value: {{ .Values.worker.walkRetryMaxInterval | default "180" | quote }}
+- name: WALK_MAX_RETRIES
+  value: {{ .Values.worker.walkMaxRetries | default "5" | quote }}
 - name: METRICS_INDEXING_ENABLED
   value: {{ (.Values.poller).metricsIndexingEnabled | default "false" | quote }}
 - name: POLL_BASE_PROFILES

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -317,7 +317,9 @@ worker:
   # task timeout in seconds (usually necessary when walk process takes a long time)
   taskTimeout: 2400
   # maximum time interval between walk attempts
-  walkRetryMaxInterval: 60
+  walkRetryMaxInterval: 180
+  # maximum number of walk retries
+  walkMaxRetries: 5
   # ignoring `occurred: OID not increasing` issues for hosts specified in the array, ex:
   #   ignoreNotIncreasingOid:
   #    - "127.0.0.1:164"

--- a/docs/bestpractices.md
+++ b/docs/bestpractices.md
@@ -63,7 +63,7 @@ worker:
   walkRetryMaxInterval: 60
 ```
 
-With the configuration from the above, 'walk' will retry exponentially until it reaches 60 seconds.
+With the configuration from the above, 'walk' will retry exponentially from 30 seconds until it reaches 60 seconds. Default value for `worker.walkRetryMaxInterval` is 180.
 
 ### SNMP Rollover
 The Rollover problem is due to the integer value stored (especially when the value is 32-bit) being finite. 

--- a/docs/configuration/worker-configuration.md
+++ b/docs/configuration/worker-configuration.md
@@ -201,27 +201,27 @@ Here you can read about Horizontal Autoscaling and how to adjust maximum replica
 ### Worker parameters
 
 | variable | description | default |
-| --- | --- | --- |
-| worker.taskTimeout | task timeout in seconds (usually necessary when walk process takes a long time) | 2400 |
-| worker.walkRetryMaxInterval | maximum time interval between walk attempts | 600 |
-| worker.poller.replicaCount | number of poller worker replicas | 2 |
-| worker.poller.autoscaling.enabled | enabling autoscaling for poller worker pods | false |
-| worker.poller.autoscaling.minReplicas | minimum number of running poller worker pods when autoscaling is enabled | 2 |
-| worker.poller.autoscaling.maxReplicas | maximum number of running poller worker pods when autoscaling is enabled | 40 |
-| worker.poller.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on poller worker pods to spawn another replica  | 80 |
-| worker.poller.resources.limits | the resources limits for poller worker container | {} |
-| worker.poller.resources.requests | the requested resources for poller worker container | {} |
-| worker.trap.replicaCount | number of trap worker replicas | 2 |
-| worker.trap.autoscaling.enabled | enabling autoscaling for trap worker pods | false |
-| worker.trap.autoscaling.minReplicas | minimum number of running trap worker pods when autoscaling is enabled | 2 |
-| worker.trap.autoscaling.maxReplicas | maximum number of running trap worker pods when autoscaling is enabled | 40 |
-| worker.trap.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on trap worker pods to spawn another replica  | 80 |
-| worker.trap.resources.limits | the resources limits for poller worker container | {} |
-| worker.trap.resources.requests | the requested resources for poller worker container | {} |
-| worker.sender.replicaCount | number of sender worker replicas | 2 |
-| worker.sender.autoscaling.enabled | enabling autoscaling for sender worker pods | false |
-| worker.sender.autoscaling.minReplicas | minimum number of running sender worker pods when autoscaling is enabled | 2 |
-| worker.sender.autoscaling.maxReplicas | maximum number of running sender worker pods when autoscaling is enabled | 40 |
-| worker.sender.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on sender worker pods to spawn another replica  | 80 |
-| worker.sender.resources.limits | the resources limits for poller worker container | {} |
-| worker.sender.resources.requests | the requested resources for poller worker container | {} |
+| --- | --- |---------|
+| worker.taskTimeout | task timeout in seconds (usually necessary when walk process takes a long time) | 2400    |
+| worker.walkRetryMaxInterval | maximum time interval between walk attempts | 180     |
+| worker.poller.replicaCount | number of poller worker replicas | 2       |
+| worker.poller.autoscaling.enabled | enabling autoscaling for poller worker pods | false   |
+| worker.poller.autoscaling.minReplicas | minimum number of running poller worker pods when autoscaling is enabled | 2       |
+| worker.poller.autoscaling.maxReplicas | maximum number of running poller worker pods when autoscaling is enabled | 40      |
+| worker.poller.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on poller worker pods to spawn another replica  | 80      |
+| worker.poller.resources.limits | the resources limits for poller worker container | {}      |
+| worker.poller.resources.requests | the requested resources for poller worker container | {}      |
+| worker.trap.replicaCount | number of trap worker replicas | 2       |
+| worker.trap.autoscaling.enabled | enabling autoscaling for trap worker pods | false   |
+| worker.trap.autoscaling.minReplicas | minimum number of running trap worker pods when autoscaling is enabled | 2       |
+| worker.trap.autoscaling.maxReplicas | maximum number of running trap worker pods when autoscaling is enabled | 40      |
+| worker.trap.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on trap worker pods to spawn another replica  | 80      |
+| worker.trap.resources.limits | the resources limits for poller worker container | {}      |
+| worker.trap.resources.requests | the requested resources for poller worker container | {}      |
+| worker.sender.replicaCount | number of sender worker replicas | 2       |
+| worker.sender.autoscaling.enabled | enabling autoscaling for sender worker pods | false   |
+| worker.sender.autoscaling.minReplicas | minimum number of running sender worker pods when autoscaling is enabled | 2       |
+| worker.sender.autoscaling.maxReplicas | maximum number of running sender worker pods when autoscaling is enabled | 40      |
+| worker.sender.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on sender worker pods to spawn another replica  | 80      |
+| worker.sender.resources.limits | the resources limits for poller worker container | {}      |
+| worker.sender.resources.requests | the requested resources for poller worker container | {}      |

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -44,6 +44,8 @@ spec:
             value: "http://release-name-mibserver/standard.txt"
           - name: LOG_LEVEL
             value: INFO
+          - name: CHAIN_OF_TASKS_EXPIRY_TIME
+            value: "60"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -44,6 +44,8 @@ spec:
             value: "http://release-name-mibserver/standard.txt"
           - name: LOG_LEVEL
             value: INFO
+          - name: CHAIN_OF_TASKS_EXPIRY_TIME
+            value: "60"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -52,7 +52,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -52,7 +52,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -52,7 +52,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -44,6 +44,8 @@ spec:
             value: "http://release-name-mibserver/standard.txt"
           - name: LOG_LEVEL
             value: INFO
+          - name: CHAIN_OF_TASKS_EXPIRY_TIME
+            value: "60"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -52,7 +52,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -52,7 +52,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -52,7 +52,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -44,6 +44,8 @@ spec:
             value: "http://release-name-mibserver/standard.txt"
           - name: LOG_LEVEL
             value: INFO
+          - name: CHAIN_OF_TASKS_EXPIRY_TIME
+            value: "60"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -44,6 +44,8 @@ spec:
             value: "http://release-name-mibserver/standard.txt"
           - name: LOG_LEVEL
             value: INFO
+          - name: CHAIN_OF_TASKS_EXPIRY_TIME
+            value: "60"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -53,7 +53,9 @@ spec:
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL
-              value: "60"
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
             - name: METRICS_INDEXING_ENABLED
               value: "false"
             - name: POLL_BASE_PROFILES

--- a/splunk_connect_for_snmp/snmp/tasks.py
+++ b/splunk_connect_for_snmp/snmp/tasks.py
@@ -43,7 +43,8 @@ logger = get_task_logger(__name__)
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB = os.getenv("MONGO_DB", "sc4snmp")
 CONFIG_PATH = os.getenv("CONFIG_PATH", "/app/config/config.yaml")
-WALK_RETRY_MAX_INTERVAL = int(os.getenv("WALK_RETRY_MAX_INTERVAL", "600"))
+WALK_RETRY_MAX_INTERVAL = int(os.getenv("WALK_RETRY_MAX_INTERVAL", "180"))
+WALK_MAX_RETRIES = int(os.getenv("WALK_MAX_RETRIES", "5"))
 SPLUNK_SOURCETYPE_TRAPS = os.getenv("SPLUNK_SOURCETYPE_TRAPS", "sc4snmp:traps")
 OID_VALIDATOR = re.compile(r"^([0-2])((\.0)|(\.[1-9][0-9]*))*$")
 
@@ -53,7 +54,7 @@ OID_VALIDATOR = re.compile(r"^([0-2])((\.0)|(\.[1-9][0-9]*))*$")
     base=Poller,
     retry_backoff=30,
     retry_backoff_max=WALK_RETRY_MAX_INTERVAL,
-    max_retries=50,
+    max_retries=WALK_MAX_RETRIES,
     autoretry_for=(
         MongoLockLocked,
         SnmpActionError,


### PR DESCRIPTION
# Description

This PR is to make walk max retries configurable, as this is hardcoded to be 50 retries and it takes a lot of resources and time to walk devices that are unavailable.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement
- [x] This change requires a documentation update

## How Has This Been Tested?

Unit tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings