### PR TITLE
fix: stop search for enterprise oid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - empty profile name when MIB family name and a polled varbind differs
+- stop mib search on vendor if oid is for enterprise tree
 
 ## [1.9.2]
 

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -390,10 +390,9 @@ class Poller(Task):
                     logger.warning(f"Error loading mib for {mib}, {e}")
 
     def is_mib_known(self, id: str, oid: str, target: str) -> Tuple[bool, str]:
-
         oid_list = tuple(oid.split("."))
-
-        start = 5
+        # if oid match enterprise, then search should stop if there is no match to vendor
+        start = 6 if oid.startswith("1.3.6.1.4.1") else 5
         for i in range(len(oid_list), start, -1):
             oid_to_check = ".".join(oid_list[:i])
             if oid_to_check in self.mib_map:


### PR DESCRIPTION
# Description

Fix to issue with matching enterprise oid to first found vendor. If enterprise oid is part of path the search will end on checking for matching vendor.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

manual test

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings