### PR TITLE
Fix/traps dns reverse lookup

### DIFF
--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -181,4 +181,10 @@ Common labels
   value: {{ .Values.worker.trap.concurrency | default "2" | quote }}
 - name: PREFETCH_COUNT
   value: {{ .Values.worker.trap.prefetch | default "1" | quote }}
+- name: RESOLVE_TRAP_ADDRESS
+  value: {{ .Values.worker.trap.resolveAddress.enabled | default "false" | quote }}
+- name: MAX_DNS_CACHE_SIZE_TRAPS
+  value: {{ .Values.worker.trap.resolveAddress.cacheSize | default "500" | quote }}
+- name: TTL_DNS_CACHE_TRAPS
+  value: {{ .Values.worker.trap.resolveAddress.cacheTTL | default "1800" | quote }}
 {{- end }}

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -267,6 +267,11 @@ worker:
   trap:
     # number of the trap replicas when autoscaling is set to false
     replicaCount: 2
+    # Use reverse dns lookup of trap ip address and send the hostname to splunk
+    resolveAddress:
+      enabled: false
+      cacheSize: 500 # maximum number of records in cache
+      cacheTTL: 1800 # time to live of the cached record in seconds
     # minimum number of threads in a pod
     concurrency: 4
     # how many tasks are consumed from the queue at once

--- a/docs/configuration/coredns-configuration.md
+++ b/docs/configuration/coredns-configuration.md
@@ -1,0 +1,141 @@
+# Configuration of CoreDNS in microk8s to use different nameservers for different domains and ip ranges
+
+
+In MicroK8s, CoreDNS is enabled by running the following command: `microk8s enable dns`.
+
+Alternatively, you can specify a list of DNS servers by running the command: `microk8s enable dns:8.8.8.8,1.1.1.1`.
+
+The servers in the provided list are expected to be capable of resolving the same addresses. 
+If one of these servers is unreachable, another one is used. 
+If the requirement is to use different DNS servers for various domains or different IP ranges in the case of reverse lookup, the configuration differs.
+
+Before executing `microk8s enable dns`, the first step is to edit `coredns.yaml`, located inside the MicroK8s installation folder.
+An example path is: `/var/snap/microk8s/common/addons/core/addons/dns/coredns.yaml`.
+
+
+Inside `coredns.yaml`, there is a complete configuration for the CoreDNS deployment.
+The only section that requires editing is the ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+    k8s-app: kube-dns
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+          lameduck 5s
+        }
+        ready
+        log . {
+          class error
+        }
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . $NAMESERVERS
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+```
+
+Changes should be made in `data.Corefile` within this ConfigMap. Presented documentation explains basic configuration. 
+For more details, refer to the official CoreDNS [documentation](https://coredns.io/manual/toc/).
+
+
+Updated ConfigMap:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+    k8s-app: kube-dns
+data:
+  Corefile: |
+      .:53 {
+        errors
+        health {
+          lameduck 5s
+        }
+        ready
+        log . {
+          class error
+        }
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . $NAMESERVERS
+        cache 1
+        loop
+        reload
+        loadbalance
+      }
+      dummyhost.com:53 {
+      errors
+        health {
+          lameduck 5s
+        }
+        ready
+        log . {
+          class error
+        }
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . 4.3.2.1
+        cache 1
+        loop
+        reload
+        loadbalance
+      }
+      2.1.in-addr.arpa:53 {
+       errors
+        health {
+          lameduck 5s
+        }
+        ready
+        log . {
+          class error
+        }
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . 4.3.2.1
+        cache 1
+        loop
+        reload
+        loadbalance
+      }
+```
+
+Two server blocks, `dummyhost.com:53` and `2.1.in-addr.arpa:53`, have been added.
+
+The `dummyhost.com:53` server block is used to resolve all hosts within the `dummyhost.com` domain. 
+The DNS server used for these hosts is specified in the forward plugin as `4.3.2.1`. 
+Additional information about the forward plugin can be found in the official CoreDNS [documentation](https://coredns.io/plugins/forward/).
+
+The `2.1.in-addr.arpa:53` server block is added for reverse DNS lookup for all devices in the IPv4 range `1.2.0.0/16`. 
+The DNS server is the same as in the `dummyhost.com:53` server block.
+
+All other DNS requests will be handled by the `8.8.8.8` server if `microk8s enable dns` is run without providing a list of DNS servers. 
+Alternatively, one of the servers provided in the list will be used in the case of running with the list of servers, 
+i.e., `microk8s enable dns:8.8.8.8,1.1.1.1`.

--- a/docs/configuration/worker-configuration.md
+++ b/docs/configuration/worker-configuration.md
@@ -24,6 +24,11 @@ worker:
   trap:
     # replicaCount: number of trap-worker pods which consumes trap tasks
     replicaCount: 2
+    # Use reverse dns lookup of trap ip address and send the hostname to splunk
+    resolveAddress:
+      enabled: false
+      cacheSize: 500 # maximum number of records in cache
+      cacheTTL: 1800 # time to live of the cached record in seconds
     #autoscaling: use it instead of replicaCount in order to make pods scalable by itself
     #autoscaling:
     #  enabled: true
@@ -197,31 +202,49 @@ you should enable autoscaling/increase maxReplicas or increase replicaCount with
 
 Here you can read about Horizontal Autoscaling and how to adjust maximum replica value to the resources you have: [Horizontal Autoscaling.](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
 
+### Reverse DNS lookup in trap worker
+
+If you want to see the hostname instead of IP address of the incoming traps in Splunk, you can enable reverse dns lookup
+for the incoming traps using the following configuration:
+
+```yaml
+worker:
+  trap:
+    resolveAddress:
+      enabled: true
+      cacheSize: 500 # maximum number of records in cache
+      cacheTTL: 1800 # time to live of the cached record in seconds
+```
+
+Trap worker uses in memory cache to store the results of the reverse dns lookup. If you restart the worker, cache will be cleared.
 
 ### Worker parameters
 
-| variable | description | default |
-| --- | --- |---------|
-| worker.taskTimeout | task timeout in seconds (usually necessary when walk process takes a long time) | 2400    |
-| worker.walkRetryMaxInterval | maximum time interval between walk attempts | 180     |
-| worker.poller.replicaCount | number of poller worker replicas | 2       |
-| worker.poller.autoscaling.enabled | enabling autoscaling for poller worker pods | false   |
-| worker.poller.autoscaling.minReplicas | minimum number of running poller worker pods when autoscaling is enabled | 2       |
-| worker.poller.autoscaling.maxReplicas | maximum number of running poller worker pods when autoscaling is enabled | 40      |
-| worker.poller.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on poller worker pods to spawn another replica  | 80      |
-| worker.poller.resources.limits | the resources limits for poller worker container | {}      |
-| worker.poller.resources.requests | the requested resources for poller worker container | {}      |
-| worker.trap.replicaCount | number of trap worker replicas | 2       |
-| worker.trap.autoscaling.enabled | enabling autoscaling for trap worker pods | false   |
-| worker.trap.autoscaling.minReplicas | minimum number of running trap worker pods when autoscaling is enabled | 2       |
-| worker.trap.autoscaling.maxReplicas | maximum number of running trap worker pods when autoscaling is enabled | 40      |
-| worker.trap.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on trap worker pods to spawn another replica  | 80      |
-| worker.trap.resources.limits | the resources limits for poller worker container | {}      |
-| worker.trap.resources.requests | the requested resources for poller worker container | {}      |
-| worker.sender.replicaCount | number of sender worker replicas | 2       |
-| worker.sender.autoscaling.enabled | enabling autoscaling for sender worker pods | false   |
-| worker.sender.autoscaling.minReplicas | minimum number of running sender worker pods when autoscaling is enabled | 2       |
-| worker.sender.autoscaling.maxReplicas | maximum number of running sender worker pods when autoscaling is enabled | 40      |
-| worker.sender.autoscaling.targetCPUUtilizationPercentage | CPU % threshold that must be exceeded on sender worker pods to spawn another replica  | 80      |
-| worker.sender.resources.limits | the resources limits for poller worker container | {}      |
-| worker.sender.resources.requests | the requested resources for poller worker container | {}      |
+| variable                                                  | description                                                                          | default |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------|---------|
+| worker.taskTimeout                                        | task timeout in seconds (usually necessary when walk process takes a long time)      | 2400    |
+| worker.walkRetryMaxInterval                               | maximum time interval between walk attempts                                          | 180     |
+| worker.poller.replicaCount                                | number of poller worker replicas                                                     | 2       |
+| worker.poller.autoscaling.enabled                         | enabling autoscaling for poller worker pods                                          | false   |
+| worker.poller.autoscaling.minReplicas                     | minimum number of running poller worker pods when autoscaling is enabled             | 2       |
+| worker.poller.autoscaling.maxReplicas                     | maximum number of running poller worker pods when autoscaling is enabled             | 40      |
+| worker.poller.autoscaling.targetCPUUtilizationPercentage  | CPU % threshold that must be exceeded on poller worker pods to spawn another replica | 80      |
+| worker.poller.resources.limits                            | the resources limits for poller worker container                                     | {}      |
+| worker.poller.resources.requests                          | the requested resources for poller worker container                                  | {}      |
+| worker.trap.replicaCount                                  | number of trap worker replicas                                                       | 2       |
+| worker.trap.resolveAddress.enabled                        | enable reverse dns lookup of the ip address of the processed trap                    | false   |
+| worker.trap.resolveAddress.cacheSize                      | maximum number of reverse dns lookup result records stored in cache                  | 500     |
+| worker.trap.resolveAddress.cacheTTL                       | time to live of the cached reverse dns lookup record in seconds                      | 1800    |
+| worker.trap.autoscaling.enabled                           | enabling autoscaling for trap worker pods                                            | false   |
+| worker.trap.autoscaling.minReplicas                       | minimum number of running trap worker pods when autoscaling is enabled               | 2       |
+| worker.trap.autoscaling.maxReplicas                       | maximum number of running trap worker pods when autoscaling is enabled               | 40      |
+| worker.trap.autoscaling.targetCPUUtilizationPercentage    | CPU % threshold that must be exceeded on trap worker pods to spawn another replica   | 80      |
+| worker.trap.resources.limits                              | the resources limits for poller worker container                                     | {}      |
+| worker.trap.resources.requests                            | the requested resources for poller worker container                                  | {}      |
+| worker.sender.replicaCount                                | number of sender worker replicas                                                     | 2       |
+| worker.sender.autoscaling.enabled                         | enabling autoscaling for sender worker pods                                          | false   |
+| worker.sender.autoscaling.minReplicas                     | minimum number of running sender worker pods when autoscaling is enabled             | 2       |
+| worker.sender.autoscaling.maxReplicas                     | maximum number of running sender worker pods when autoscaling is enabled             | 40      |
+| worker.sender.autoscaling.targetCPUUtilizationPercentage  | CPU % threshold that must be exceeded on sender worker pods to spawn another replica | 80      |
+| worker.sender.resources.limits                            | the resources limits for poller worker container                                     | {}      |
+| worker.sender.resources.requests                          | the requested resources for poller worker container                                  | {}      |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Redis: "configuration/redis-configuration.md"
       - SNMPv3 configuration: "configuration/snmpv3-configuration.md"
       - Splunk Infrastructure Monitoring: "configuration/sim-configuration.md"
+      - CoreDNS: "configuration/coredns-configuration.md"
   - Offline Installation:
       - Install Microk8s: "offlineinstallation/offline-microk8s.md"
       - Install Splunk OpenTelemetry Collector for Kubernetes: "offlineinstallation/offline-sck.md"

--- a/splunk_connect_for_snmp/common/custom_cache.py
+++ b/splunk_connect_for_snmp/common/custom_cache.py
@@ -1,0 +1,31 @@
+import math
+import time
+from functools import lru_cache, update_wrapper
+from typing import Any, Callable
+
+
+def _ttl_hash_gen(seconds: int):
+    start_time = time.time()
+    while True:
+        yield math.floor((time.time() - start_time) / seconds)
+
+
+def ttl_lru_cache(maxsize: int = 128, ttl: int = -1):
+    if ttl <= 0:
+        ttl = 65536
+    hash_gen = _ttl_hash_gen(ttl)
+
+    def wrapper(func: Callable) -> Callable:
+        @lru_cache(maxsize)
+        def ttl_func(ttl_hash, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        def wrapped(*args, **kwargs) -> Any:
+            th = next(hash_gen)
+            return ttl_func(th, *args, **kwargs)
+
+        setattr(wrapped, "cache_info", ttl_func.cache_info)
+        setattr(wrapped, "cache_clear", ttl_func.cache_clear)
+        return update_wrapper(wrapped, func)
+
+    return wrapper

--- a/test/common/test_custom_cache.py
+++ b/test/common/test_custom_cache.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+from unittest.mock import mock_open, patch
+
+from splunk_connect_for_snmp.common.custom_cache import ttl_lru_cache
+
+
+def result_of_cache(x):
+    return x
+
+
+class TestCustomCache(TestCase):
+    @patch("time.time")
+    def test_ttl(self, m_time):
+        m_time.side_effect = [5, 5, 10, 15]
+        cached = ttl_lru_cache(ttl=6)(result_of_cache)
+
+        cached(1)
+        assert "hits=0" in f"{cached.cache_info()}"
+        assert "misses=1" in f"{cached.cache_info()}"
+
+        cached(1)
+        assert "hits=1" in f"{cached.cache_info()}"
+        assert "misses=1" in f"{cached.cache_info()}"
+
+        cached(1)
+        assert "hits=1" in f"{cached.cache_info()}"
+        assert "misses=2" in f"{cached.cache_info()}"
+
+        cached.cache_clear()
+
+    @patch("time.time")
+    def test_max_size(self, m_time):
+        m_time.side_effect = [5, 5, 10, 15, 20, 25]
+        maxsize = 2
+        cached = ttl_lru_cache(maxsize=maxsize, ttl=300)(result_of_cache)
+
+        cached(1)
+        assert "hits=0" in f"{cached.cache_info()}"
+        assert "misses=1" in f"{cached.cache_info()}"
+        assert f"maxsize={maxsize}" in f"{cached.cache_info()}"
+        assert "currsize=1" in f"{cached.cache_info()}"
+
+        cached(1)
+        assert "hits=1" in f"{cached.cache_info()}"
+        assert "misses=1" in f"{cached.cache_info()}"
+        assert f"maxsize={maxsize}" in f"{cached.cache_info()}"
+        assert "currsize=1" in f"{cached.cache_info()}"
+
+        cached(2)
+        assert "hits=1" in f"{cached.cache_info()}"
+        assert "misses=2" in f"{cached.cache_info()}"
+        assert f"maxsize={maxsize}" in f"{cached.cache_info()}"
+        assert "currsize=2" in f"{cached.cache_info()}"
+
+        cached(3)
+        assert "hits=1" in f"{cached.cache_info()}"
+        assert "misses=3" in f"{cached.cache_info()}"
+        assert f"maxsize={maxsize}" in f"{cached.cache_info()}"
+        assert "currsize=2" in f"{cached.cache_info()}"
+
+        cached(3)
+        assert "hits=2" in f"{cached.cache_info()}"
+        assert "misses=3" in f"{cached.cache_info()}"
+        assert f"maxsize={maxsize}" in f"{cached.cache_info()}"
+        assert "currsize=2" in f"{cached.cache_info()}"
+
+        cached.cache_clear()


### PR DESCRIPTION
# Description

This PR will add the possibility of configuring reverse dns lookup for the incoming traps IP addresses and sending the host name instead of the IP address to Splunk. 

## Type of change

Please delete options that are not relevant.

- [x] New feature

## How Has This Been Tested?

Manual testing and testing of maximum cache capacity.
Unit tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings