### PR TITLE
chore: fix semantic-release-replace-plugin

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -84,7 +84,7 @@ jobs:
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.SA_GPG_PASSPHRASE }}
           extra_plugins: |
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin@1.2.7
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
 


### PR DESCRIPTION
# Description

Update semantic-release-replace-plugin as @google/semantic-release-replace-plugin got depricated.

