### PR TITLE
fix: add support for security level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - added `yamllint` validation for the `values.yaml` formatting
 - added "in code" validation of groups and profiles
 - added logs configuration to docker compose deployment
+- add support for different security level in snmp v3
 
 ### Fixed
 - fixed a bug with configuration from values.yaml not being transferred to the UI while migrating to SC4SNMP-UI

--- a/splunk_connect_for_snmp/snmp/auth.py
+++ b/splunk_connect_for_snmp/snmp/auth.py
@@ -136,8 +136,8 @@ def get_auth_v3(logger, ir: InventoryRecord, snmp_engine: SnmpEngine) -> UsmUser
         )
         return UsmUserData(
             username,
-            authKey=auth_key,
-            privKey=priv_key,
+            authKey=auth_key if auth_key else None,
+            privKey=priv_key if priv_key else None,
             authProtocol=auth_protocol,
             privProtocol=priv_protocol,
             securityEngineId=security_engine_id,
@@ -161,7 +161,6 @@ def get_auth_v1(ir: InventoryRecord) -> CommunityData:
 def get_auth(
     logger, ir: InventoryRecord, snmp_engine: SnmpEngine
 ) -> Union[UsmUserData, CommunityData]:
-
     if ir.version == "1":
         return get_auth_v1(ir)
     elif ir.version == "2c":


### PR DESCRIPTION
# Description

Adds support for different security levels in snmpv3:
- NoAuthNoPriv
- AuthNoPriv
- AuthPriv

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

manual test, unit test

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings