### PR TITLE
feat: support ipv6 for kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - add metrics dashboard
 
 ### Changed
+- add support for IPv6 polling and traps for kubernetes deployment
 
 ### Fixed
 

--- a/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -84,10 +84,21 @@ spec:
                   secretKeyRef:
                     name: {{ include "splunk-connect-for-snmp.name" . }}-splunk
                     key: hec_token
+            - name: IPv6_ENABLED
+              {{- if has "IPv6" .Values.traps.ipFamilies}}
+              value: "true"
+              {{ else }}
+              value: "false"
+              {{- end }}
           ports:
             - name: snmp-udp
               containerPort: 2162
               protocol: UDP
+            {{- if has "IPv6" .Values.traps.ipFamilies}}
+            - name: snmp-udp6
+              containerPort: 2163
+              protocol: UDP
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/charts/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
   {{- if .Values.traps.service.usemetallb }}
     metallb.universe.tf/allow-shared-ip: {{ .Values.traps.service.metallbsharingkey | default "splunk-connect" | quote }}
+    metallb.universe.tf/loadBalancerIPs: {{ .Values.traps.loadBalancerIP }}
   {{- end }}
   {{- if .Values.traps.service.annotations }}
 {{ toYaml .Values.traps.service.annotations | indent 4 }}
@@ -20,7 +21,8 @@ spec:
   type: {{ .Values.traps.service.type }}
   externalTrafficPolicy: {{ .Values.traps.service.externalTrafficPolicy | default "Local" }}
   {{- if .Values.traps.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.traps.loadBalancerIP }}
+  ipFamilyPolicy: {{ .Values.traps.ipFamilyPolicy }}
+  ipFamilies: {{ .Values.traps.ipFamilies | toYaml | nindent 2 }}
   {{- end }}
   ports:
     - port: {{ .Values.traps.service.port }}
@@ -30,6 +32,15 @@ spec:
       targetPort: 2162
       protocol: UDP
       name: snmp-udp
+    {{- if has "IPv6" .Values.traps.ipFamilies}}
+    - port: {{ .Values.traps.service.ipv6Port | default 2163}}
+      {{- if and .Values.traps.service.nodePort (eq .Values.traps.service.type "NodePort")}}
+      nodePort: {{ .Values.traps.service.ipv6NodePort | default 30003 }}
+      {{- end }}
+      targetPort: 2163
+      protocol: UDP
+      name: snmp-udp6
+    {{- end }}
   selector:
     {{- include "splunk-connect-for-snmp.traps.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/splunk-connect-for-snmp/values.schema.json
+++ b/charts/splunk-connect-for-snmp/values.schema.json
@@ -719,11 +719,23 @@
             },
             "nodePort": {
               "type": "integer"
+            },
+            "ipv6Port": {
+              "type": "integer"
+            },
+            "ipv6NodePort": {
+              "type": "integer"
             }
           }
         },
         "loadBalancerIP": {
           "type": "string"
+        },
+        "ipFamilyPolicy": {
+          "type": "string"
+        },
+        "ipFamilies": {
+          "type": "array"
         },
         "resources": {
           "type": "object",

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -425,13 +425,19 @@ traps:
     # on a multi-node it's better to set this as NodePort and configure traps.service.nodePort
     type: LoadBalancer
     port: 162
+   # ipv6Port: 2163
+
     # nodePort will be set only when type of service is a NodePort
     #nodePort: 30000
+    #ipv6NodePort: 30003
 
   #loadBalancerIP must be set to the IP address in the metallb pool.
   #It is required when service type is set to LoadBalancer.
   #loadBalancerIP: 18.117.100.37
   loadBalancerIP: ""
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+   - IPv4
 
   resources: {}
     # limits:

--- a/docs/configuration/trap-configuration.md
+++ b/docs/configuration/trap-configuration.md
@@ -94,6 +94,13 @@ See the following example:
 traps:
   loadBalancerIP: 10.202.4.202
 ```
+If you have enabled the Ipv6 you need to pass IP addresses for both IPv4 and IPv6.
+See the following example:
+
+```yaml
+traps:
+  loadBalancerIP: 10.202.4.202,2001:0DB8:AC10:FE01:0000:0000:0000:0001
+```
 
 If you want to use the SC4SNMP trap receiver in K8S cluster, configure `NodePort` instead. Use the following configuration:
 

--- a/docs/configuration/values-params-description.md
+++ b/docs/configuration/values-params-description.md
@@ -161,10 +161,14 @@ Detailed documentation about configuring traps can be found in [Traps](../config
 | `service.usemetallb`                            | Enables using metallb                                                                                                           | `true`           |
 | `service.metallbsharingkey`                     | Sets metallb.universe.tf/allow-shared-ip annotation in trap service                                                             | `splunk-connect` |
 | `service.type`                                  | [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)  | `LoadBalancer`   |
-| `service.port`                                  | Port of the service to use                                                                                                      | `162`            |
+| `service.port`                                  | Port of the service to use for IPv4                                                                                             | `162`            |
 | `service.nodePort`                              | Port when the `service.type` is `nodePort`                                                                                      | `30000`          |
 | `service.externalTrafficPolicy`                 | Controls how Kubernetes routes traffic                                                                                          | `Local`          |
-| `loadBalancerIP`                                | Sets loadBalancer IP address in the metallb pool                                                                                |                  |
+| `service.ipv6Port`                              | Port of the service to use for IPv6                                                                                             | `162`            |
+| `service.ipv6NodePort`                          | Port when the `service.type` is `nodePort` and IPv6 is enabled                                                                  | `2163`           |
+| `loadBalancerIP`                                | Sets loadBalancer IP address in the metallb pool                                                                                | `30001`          |
+| `ipFamilyPolicy`                                | Specifies if the service is dual stack or single stack                                                                          | `SingleStack`    |
+| `ipFamilies`                                    | Defines the address families used for chosen `ipFamilyPolicy`                                                                   | `IPv4`           |
 | `resources`                                     | CPU and memory limits and requests for pod                                                                                      |                  |
 | `autoscaling.enabled`                           | Enables autoscaling for pods                                                                                                    | `false`          |
 | `autoscaling.minReplicas`                       | Minimum number of running pods when autoscaling is enabled                                                                      | `1`              |

--- a/docs/gettingstarted/enable-ipv6.md
+++ b/docs/gettingstarted/enable-ipv6.md
@@ -1,0 +1,65 @@
+# Enabling IPv6 for SC4SNMP
+
+Default installation of SC4SNMP does not support polling or receiving trap notifications from IPv6 addresses. To enable IPv6, follow instruction below.
+
+## Microk8s
+To configure dual-stack network on microk8s follow instructions at [Microk8s page](https://microk8s.io/docs/how-to-dual-stack).
+After completing the steps, you can follow the instruction at [Microk8s installation on Ubuntu](mk8s/k8s-microk8s.md#microk8s-installation-on-ubuntu) 
+to install microk8s.
+
+## Calico
+The default CNI used for microk8s is Calico. For pods to be able to reach internet over IPv6, you need to enable 
+the `natOutgoing` parameter in ipv6 ip pool configuration from calico.
+To set it create the yaml file with the following content:
+```
+# calico-ippool.yaml
+---
+apiVersion: crd.projectcalico.org/v1
+kind: IPPool
+metadata:
+  name: default-ipv6-ippool
+spec:
+  natOutgoing: true
+```
+You can check with command `microk8s kubectl get ippools -n kube-system` the default name of the ip pool for IPv6. If it differs from `default-ipv6-ippool` you need to change the name in the yaml file.
+Then apply the configuration with the following command:
+```
+microk8s kubectl apply -f calico-ippool.yaml
+```
+
+After those changes you can restart the microk8s fot the changes to be applied with the following commands:
+```
+microk8s stop
+microk8s start
+```
+
+## Metallb
+As of version `1.30` of microk8s, Metallb add-on does not support passing the IPv6 addresses in enable command. To 
+add the IPv6 addresses to your Metallb configuration, you can prepare the yaml file with configuration like below:
+```
+# addresspool.yaml
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-addresspool
+  namespace: metallb-system
+spec: 
+  addresses:
+  - 1.1.1.1/32
+  - 2001:0db8:ac10:fe01:0000:0000:0000:0001/128
+```
+You can check with command `microk8s kubectl get ipaddresspool -n metallb-system` the default name of the ip address pool created in metallb. If it differs from `default-addresspool` you need to change the name in the yaml file.
+You can add the single ip or subnets for both IPv4 and IPv6 under `spec.addresses` section. After preparing the yaml file, apply the configuration with the following command:
+```
+microk8s kubectl apply -f addresspool.yaml
+```
+
+## SC4SNMP
+To configure traps to receive notification from IPv4 and IPv6 addresses, you need to add the following configuration to the `values.yaml` file:
+```
+traps:
+  ipFamilyPolicy: RequireDualStack
+  ipFamilies: ["IPv4", "IPv6"]
+```
+Default trap port for notifications for IPv6 is `2163`. You can change it to any other port if needed with `traps.service.ipv6Port` parameter.

--- a/docs/gettingstarted/mk8s/k8s-microk8s.md
+++ b/docs/gettingstarted/mk8s/k8s-microk8s.md
@@ -19,6 +19,11 @@ Three node minimum per node:
 The following quick start guidance is based on Ubuntu 20.04LTS with MicroK8s and internet access. See other deployment options
 in the MicroK8s [documentation](https://microk8s.io/docs), including offline and with proxy. 
 
+## Enabling IPv6
+
+If you plan to poll or receive trap notifications from IPv6 addresses, firstly check the instructions for [enabling 
+IPv6](../enable-ipv6.md).
+
 ## Install MicroK8s using Snap
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - Platform Microk8s: "gettingstarted/mk8s/k8s-microk8s.md"
       - Install Splunk OpenTelemetry Collector for Kubernetes: "gettingstarted/sck-installation.md"
       - Install SC4SNMP: "gettingstarted/sc4snmp-installation.md"
+      - Enable IPv6: "gettingstarted/enable-ipv6.md"
   - Configuration:
       - Deployment: "configuration/deployment-configuration.md"
       - Configurable values: "configuration/values-params-description.md"

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: "http://release-name-mibserver/standard.txt"
             - name: LOG_LEVEL
               value: INFO
+            - name: PYSNMP_DEBUG
+              value: ""
             - name: SPLUNK_HEC_SCHEME
               value: "https"
             - name: SPLUNK_HEC_HOST
@@ -71,6 +73,8 @@ spec:
                   secretKeyRef:
                     name: splunk-connect-for-snmp-splunk
                     key: hec_token
+            - name: IPv6_ENABLED
+              value: "false"
           ports:
             - name: snmp-udp
               containerPort: 2162

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -12,11 +12,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     metallb.universe.tf/allow-shared-ip: "splunk-connect"
+    metallb.universe.tf/loadBalancerIPs: 10.202.6.213
     
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-  loadBalancerIP: 10.202.6.213
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+  - IPv4
   ports:
     - port: 162
       targetPort: 2162

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "http://release-name-mibserver/standard.txt"
             - name: LOG_LEVEL
               value: INFO
+            - name: PYSNMP_DEBUG
+              value: ""
             - name: SPLUNK_HEC_SCHEME
               value: "https"
             - name: SPLUNK_HEC_HOST
@@ -70,6 +72,8 @@ spec:
                   secretKeyRef:
                     name: splunk-connect-for-snmp-splunk
                     key: hec_token
+            - name: IPv6_ENABLED
+              value: "false"
           ports:
             - name: snmp-udp
               containerPort: 2162

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -12,11 +12,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     metallb.universe.tf/allow-shared-ip: "splunk-connect"
+    metallb.universe.tf/loadBalancerIPs: 10.202.6.213
     
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-  loadBalancerIP: 10.202.6.213
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+  - IPv4
   ports:
     - port: 162
       targetPort: 2162

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "http://release-name-mibserver/standard.txt"
             - name: LOG_LEVEL
               value: INFO
+            - name: PYSNMP_DEBUG
+              value: ""
             - name: SPLUNK_HEC_SCHEME
               value: "https"
             - name: SPLUNK_HEC_HOST
@@ -70,6 +72,8 @@ spec:
                   secretKeyRef:
                     name: splunk-connect-for-snmp-splunk
                     key: hec_token
+            - name: IPv6_ENABLED
+              value: "false"
           ports:
             - name: snmp-udp
               containerPort: 2162

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -12,11 +12,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     metallb.universe.tf/allow-shared-ip: "splunk-connect"
+    metallb.universe.tf/loadBalancerIPs: 10.202.6.213
     
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-  loadBalancerIP: 10.202.6.213
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+  - IPv4
   ports:
     - port: 162
       targetPort: 2162

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: "http://release-name-mibserver/standard.txt"
             - name: LOG_LEVEL
               value: INFO
+            - name: PYSNMP_DEBUG
+              value: ""
             - name: SPLUNK_HEC_SCHEME
               value: "https"
             - name: SPLUNK_HEC_HOST
@@ -71,6 +73,8 @@ spec:
                   secretKeyRef:
                     name: splunk-connect-for-snmp-splunk
                     key: hec_token
+            - name: IPv6_ENABLED
+              value: "false"
           ports:
             - name: snmp-udp
               containerPort: 2162

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -12,11 +12,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     metallb.universe.tf/allow-shared-ip: "splunk-connect"
+    metallb.universe.tf/loadBalancerIPs: 10.202.6.213
     
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-  loadBalancerIP: 10.202.6.213
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+  - IPv4
   ports:
     - port: 162
       targetPort: 2162

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: "http://release-name-mibserver/standard.txt"
             - name: LOG_LEVEL
               value: INFO
+            - name: PYSNMP_DEBUG
+              value: ""
             - name: SPLUNK_HEC_SCHEME
               value: "https"
             - name: SPLUNK_HEC_HOST
@@ -71,6 +73,8 @@ spec:
                   secretKeyRef:
                     name: splunk-connect-for-snmp-splunk
                     key: hec_token
+            - name: IPv6_ENABLED
+              value: "false"
           ports:
             - name: snmp-udp
               containerPort: 2162

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -12,11 +12,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     metallb.universe.tf/allow-shared-ip: "splunk-connect"
+    metallb.universe.tf/loadBalancerIPs: 10.202.6.213
     
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-  loadBalancerIP: 10.202.6.213
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+  - IPv4
   ports:
     - port: 162
       targetPort: 2162

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: "http://release-name-mibserver/standard.txt"
             - name: LOG_LEVEL
               value: INFO
+            - name: PYSNMP_DEBUG
+              value: ""
             - name: SPLUNK_HEC_SCHEME
               value: "https"
             - name: SPLUNK_HEC_HOST
@@ -71,6 +73,8 @@ spec:
                   secretKeyRef:
                     name: splunk-connect-for-snmp-splunk
                     key: hec_token
+            - name: IPv6_ENABLED
+              value: "false"
           ports:
             - name: snmp-udp
               containerPort: 2162

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -12,11 +12,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     metallb.universe.tf/allow-shared-ip: "splunk-connect"
+    metallb.universe.tf/loadBalancerIPs: 10.202.6.213
     
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-  loadBalancerIP: 10.202.6.213
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+  - IPv4
   ports:
     - port: 162
       targetPort: 2162

--- a/splunk_connect_for_snmp/common/inventory_processor.py
+++ b/splunk_connect_for_snmp/common/inventory_processor.py
@@ -33,7 +33,7 @@ ALLOWED_KEYS_VALUES = [
 
 def transform_key_to_address(target):
     if ":" in target:
-        address, port = target.split(":")
+        address, port = target.rsplit(":", 1)
     else:
         return target, 161
     return address, int(port)
@@ -41,7 +41,7 @@ def transform_key_to_address(target):
 
 def transform_address_to_key(address, port):
     if not port or int(port) == 161:
-        return address
+        return f"{address}:161"
     else:
         return f"{address}:{port}"
 

--- a/splunk_connect_for_snmp/snmp/auth.py
+++ b/splunk_connect_for_snmp/snmp/auth.py
@@ -20,6 +20,7 @@ from pysnmp.hlapi import (
     CommunityData,
     ContextData,
     SnmpEngine,
+    Udp6TransportTarget,
     UdpTransportTarget,
     UsmUserData,
     getCmd,
@@ -54,9 +55,7 @@ def get_secret_value(
 def get_security_engine_id(logger, ir: InventoryRecord, snmp_engine: SnmpEngine):
     observer_context: Dict[Any, Any] = {}
 
-    transport_target = UdpTransportTarget(
-        (ir.address, ir.port), timeout=UDP_CONNECTION_TIMEOUT
-    )
+    transport_target = setup_transport_target(ir)
 
     # Register a callback to be invoked at specified execution point of
     # SNMP Engine and passed local variables at execution point's local scope
@@ -85,6 +84,18 @@ def get_security_engine_id(logger, ir: InventoryRecord, snmp_engine: SnmpEngine)
     )
     logger.debug(f"securityEngineId={security_engine_id} for device {ir.address}")
     return security_engine_id
+
+
+def setup_transport_target(ir):
+    if ":" in ir.address:
+        transport = Udp6TransportTarget(
+            (ir.address, ir.port), timeout=UDP_CONNECTION_TIMEOUT
+        )
+    else:
+        transport = UdpTransportTarget(
+            (ir.address, ir.port), timeout=UDP_CONNECTION_TIMEOUT
+        )
+    return transport
 
 
 def fetch_security_engine_id(observer_context, error_indication, ipaddress):

--- a/test/inventory/test_loader.py
+++ b/test/inventory/test_loader.py
@@ -152,13 +152,13 @@ class TestLoader(TestCase):
 
         result = gen_walk_task(inventory_record)
 
-        self.assertEqual("sc4snmp;192.68.0.1;walk", result["name"])
+        self.assertEqual("sc4snmp;192.68.0.1:161;walk", result["name"])
         self.assertEqual("splunk_connect_for_snmp.snmp.tasks.walk", result["task"])
-        self.assertEqual("192.68.0.1", result["target"])
+        self.assertEqual("192.68.0.1:161", result["target"])
         self.assertEqual([], result["args"])
         self.assertEqual(
             {
-                "address": "192.68.0.1",
+                "address": "192.68.0.1:161",
                 "profile": None,
                 "chain_of_tasks_expiry_time": chain_of_tasks_expiry_time,
             },
@@ -250,10 +250,10 @@ class TestLoader(TestCase):
         periodic_obj_mock = Mock()
         m_taskManager.return_value = periodic_obj_mock
         m_load_profiles.return_value = profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
         self.assertEqual(
             {
-                "address": "192.168.0.1",
+                "address": "192.168.0.1:161",
                 "profile": "walk2",
                 "chain_of_tasks_expiry_time": 120,
             },
@@ -305,7 +305,7 @@ class TestLoader(TestCase):
         periodic_obj_mock = Mock()
         m_taskManager.return_value = periodic_obj_mock
         m_load_profiles.return_value = default_profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
 
         periodic_obj_mock.manage_task.assert_called_with(**expected_managed_task)
 
@@ -354,7 +354,7 @@ class TestLoader(TestCase):
         periodic_obj_mock = Mock()
         m_taskManager.return_value = periodic_obj_mock
         m_load_profiles.return_value = default_profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
 
         periodic_obj_mock.manage_task.assert_called_with(**expected_managed_task)
 
@@ -405,7 +405,7 @@ class TestLoader(TestCase):
         periodic_obj_mock.did_expiry_time_change.return_value = False
         m_migrate.return_value = False
         m_load_profiles.return_value = default_profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
 
         periodic_obj_mock.manage_task.assert_not_called()
 
@@ -458,7 +458,7 @@ class TestLoader(TestCase):
         m_taskManager.return_value = periodic_obj_mock
         periodic_obj_mock.did_expiry_time_change.return_value = True
         m_load_profiles.return_value = default_profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
 
         periodic_obj_mock.manage_task.assert_called_with(**expected_managed_task)
 
@@ -504,7 +504,7 @@ class TestLoader(TestCase):
         m_taskManager.return_value = periodic_obj_mock
         m_taskManager.get_chain_of_task_expiry.return_value = 180
         m_load_profiles.return_value = default_profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
 
         m_mongo_collection.assert_not_called()
         periodic_obj_mock.manage_task.assert_not_called()
@@ -550,16 +550,16 @@ class TestLoader(TestCase):
         periodic_obj_mock = Mock()
         m_taskManager.return_value = periodic_obj_mock
         m_load_profiles.return_value = default_profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
 
-        periodic_obj_mock.delete_all_tasks_of_host.assert_called_with("192.168.0.1")
+        periodic_obj_mock.delete_all_tasks_of_host.assert_called_with("192.168.0.1:161")
         m_delete.assert_called_with({"address": "192.168.0.1", "port": 161})
 
         calls = m_remove.call_args_list
 
         self.assertEqual(2, len(calls))
-        self.assertEqual(({"address": "192.168.0.1"},), calls[0].args)
-        self.assertEqual(({"address": "192.168.0.1"},), calls[1].args)
+        self.assertEqual(({"address": "192.168.0.1:161"},), calls[0].args)
+        self.assertEqual(({"address": "192.168.0.1:161"},), calls[1].args)
 
     @mock.patch(
         "splunk_connect_for_snmp.common.inventory_processor.CONFIG_FROM_MONGO", False
@@ -606,7 +606,7 @@ class TestLoader(TestCase):
         periodic_obj_mock = Mock()
         m_taskManager.return_value = periodic_obj_mock
         m_load_profiles.return_value = default_profiles
-        self.assertEqual(False, load())
+        self.assertFalse(load())
 
         periodic_obj_mock.delete_all_tasks_of_host.assert_called_with("192.168.0.1:345")
         m_delete.assert_called_with({"address": "192.168.0.1", "port": 345})
@@ -669,11 +669,11 @@ class TestLoader(TestCase):
         m_manage_task.side_effect = Exception("Boom!")
         m_load_profiles.return_value = default_profiles
 
-        self.assertEqual(True, load())
+        self.assertTrue(load())
 
     def test_transform_address_to_key_161(self):
-        self.assertEqual(transform_address_to_key("127.0.0.1", 161), "127.0.0.1")
-        self.assertEqual(transform_address_to_key("127.0.0.1", "161"), "127.0.0.1")
+        self.assertEqual(transform_address_to_key("127.0.0.1", 161), "127.0.0.1:161")
+        self.assertEqual(transform_address_to_key("127.0.0.1", "161"), "127.0.0.1:161")
 
     def test_transform_address_to_key(self):
         self.assertEqual(transform_address_to_key("127.0.0.1", 32), "127.0.0.1:32")

--- a/test/snmp/test_do_work.py
+++ b/test/snmp/test_do_work.py
@@ -29,7 +29,7 @@ class TestDoWork(TestCase):
     @patch("mongolock.MongoLock.release", MagicMock())
     @patch("splunk_connect_for_snmp.snmp.auth.get_auth", None)
     @patch("splunk_connect_for_snmp.snmp.manager.get_context_data", MagicMock())
-    @patch("splunk_connect_for_snmp.snmp.manager.UdpTransportTarget", MagicMock())
+    @patch("splunk_connect_for_snmp.snmp.manager.setup_transport_target", MagicMock())
     def test_do_work_no_work_to_do(self):
         poller = Poller.__new__(Poller)
         poller.last_modified = 1609675634
@@ -57,7 +57,7 @@ class TestDoWork(TestCase):
     @patch("mongolock.MongoLock.release", MagicMock())
     @patch("splunk_connect_for_snmp.snmp.auth.get_auth", None)
     @patch("splunk_connect_for_snmp.snmp.manager.get_context_data", MagicMock())
-    @patch("splunk_connect_for_snmp.snmp.manager.UdpTransportTarget", MagicMock())
+    @patch("splunk_connect_for_snmp.snmp.manager.setup_transport_target", MagicMock())
     @patch("splunk_connect_for_snmp.snmp.manager.bulkCmd")
     @patch("splunk_connect_for_snmp.snmp.manager.getCmd")
     @patch("splunk_connect_for_snmp.common.collection_manager.ProfilesManager")
@@ -93,7 +93,7 @@ class TestDoWork(TestCase):
     @patch("mongolock.MongoLock.release", MagicMock())
     @patch("splunk_connect_for_snmp.snmp.auth.get_auth", None)
     @patch("splunk_connect_for_snmp.snmp.manager.get_context_data", MagicMock())
-    @patch("splunk_connect_for_snmp.snmp.manager.UdpTransportTarget", MagicMock())
+    @patch("splunk_connect_for_snmp.snmp.manager.setup_transport_target", MagicMock())
     @patch("splunk_connect_for_snmp.snmp.manager.bulkCmd")
     @patch("splunk_connect_for_snmp.snmp.manager.getCmd")
     @patch(
@@ -136,7 +136,7 @@ class TestDoWork(TestCase):
     @patch("mongolock.MongoLock.release", MagicMock())
     @patch("splunk_connect_for_snmp.snmp.auth.get_auth", None)
     @patch("splunk_connect_for_snmp.snmp.manager.get_context_data", MagicMock())
-    @patch("splunk_connect_for_snmp.snmp.manager.UdpTransportTarget", MagicMock())
+    @patch("splunk_connect_for_snmp.snmp.manager.setup_transport_target", MagicMock())
     @patch("splunk_connect_for_snmp.snmp.manager.bulkCmd")
     @patch("splunk_connect_for_snmp.snmp.manager.getCmd")
     @patch(


### PR DESCRIPTION
# Description

Adds to SC4SNMP support for polling and receiving traps notifications from IPv6 devices.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature

## How Has This Been Tested?

unit, integration and manual tests

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings