### PR TITLE
fix: migrate base image on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.10-bullseye AS base
+FROM python:3.10-alpine AS base
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1
+RUN apk add -U git
 RUN mkdir /app
 WORKDIR /app
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 . /app/.venv/bin/activate
 LOG_LEVEL=${LOG_LEVEL:=INFO}


### PR DESCRIPTION
# Description

Migrate base docker image to Alpine for reduce CVEs:

Before: https://hub.docker.com/layers/library/python/3.10-bullseye/images/sha256-6aeb2ae527d111aabcfbc7340c70f2799371a3e6cbce136534153940b230cb79

After: https://hub.docker.com/layers/library/python/3.10-alpine3.21/images/sha256-2f8a694c5090bd071278f8280877d157fc766ef93abd3712d86390e0e298bf06

Biggest difference migration from Debian to Alpine, that alpine using `musl` instead of `glibc` that can give some side effects. By this reason I also tested it also manually

## Type of change

- [x] Dependency update

## How Has This Been Tested?

Runned whole test suite and run it locally

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings