### PR TITLE
fix: redis headless service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- change redis service name workers call from redis-headless to redis-master
+
+### Fixed
+
+
 ## [1.12.2]
 
 ### Changed

--- a/charts/splunk-connect-for-snmp/templates/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/_helpers.tpl
@@ -7,7 +7,11 @@
 {{- end }}  
 
 {{- define "splunk-connect-for-snmp.celery_url" -}}
+{{- if and ( eq .Values.redis.architecture "replication" ) .Values.redis.sentinel.enabled  }}
+{{- printf "redis://%s-redis:6379/0" .Release.Name }}
+{{- else }}
 {{- printf "redis://%s-redis-master:6379/0" .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{- define "splunk-connect-for-snmp.redis_url" -}}

--- a/charts/splunk-connect-for-snmp/templates/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/_helpers.tpl
@@ -7,11 +7,11 @@
 {{- end }}  
 
 {{- define "splunk-connect-for-snmp.celery_url" -}}
-{{- printf "redis://%s-redis-headless:6379/0" .Release.Name }}
+{{- printf "redis://%s-redis-master:6379/0" .Release.Name }}
 {{- end }}
 
 {{- define "splunk-connect-for-snmp.redis_url" -}}
-{{- printf "redis://%s-redis-headless:6379/1" .Release.Name }}
+{{- printf "redis://%s-redis-master:6379/1" .Release.Name }}
 {{- end }}
 
 {{/*

--- a/charts/splunk-connect-for-snmp/templates/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/_helpers.tpl
@@ -11,7 +11,11 @@
 {{- end }}
 
 {{- define "splunk-connect-for-snmp.redis_url" -}}
+{{- if and ( eq .Values.redis.architecture "replication" ) .Values.redis.sentinel.enabled  }}
+{{- printf "redis://%s-redis:6379/1" .Release.Name }}
+{{- else }}
 {{- printf "redis://%s-redis-master:6379/1" .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/splunk-connect-for-snmp/templates/ui/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/ui/_helpers.tpl
@@ -105,11 +105,11 @@ Return full image for thr UI back end.
 {{- end }}
 
 {{- define "splunk-connect-for-snmp-ui.celery_url" -}}
-{{- printf "redis://%s-redis-headless:6379/2" .Release.Name }}
+{{- printf "redis://%s-redis-master:6379/2" .Release.Name }}
 {{- end }}
 
 {{- define "splunk-connect-for-snmp-ui.redis_url" -}}
-{{- printf "redis://%s-redis-headless:6379/3" .Release.Name }}
+{{- printf "redis://%s-redis-master:6379/3" .Release.Name }}
 {{- end }}
 
 {{- define "splunk-connect-for-snmp-ui.hostMountPath" -}}

--- a/docs/microk8s/configuration/step-by-step-poll.md
+++ b/docs/microk8s/configuration/step-by-step-poll.md
@@ -136,8 +136,8 @@ microk8s kubectl logs -f snmp-splunk-connect-for-snmp-inventory-g4bs7  -n sc4snm
 See the following example output:
 
 ```yaml
-Successfully connected to redis://snmp-redis-headless:6379/0
-Successfully connected to redis://snmp-redis-headless:6379/1
+Successfully connected to redis://snmp-redis-master:6379/0
+Successfully connected to redis://snmp-redis-master:6379/1
 Successfully connected to mongodb://snmp-mongodb:27017
 Successfully connected to http://snmp-mibserver/index.csv
 {"message": "Loading inventory from /app/inventory/inventory.csv", "time": "2022-09-05T14:30:30.605420", "level": "INFO"}

--- a/docs/microk8s/sc4snmp-installation.md
+++ b/docs/microk8s/sc4snmp-installation.md
@@ -120,7 +120,7 @@ Here is an example of the correct setup:
 
 ```
 NAME                                TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)         AGE
-snmp-redis-headless                 ClusterIP      None             <none>        6379/TCP        33h
+snmp-redis-master                 ClusterIP      None             <none>        6379/TCP        33h
 snmp-mongodb                        ClusterIP      10.152.183.147   <none>        27017/TCP       33h
 snmp-mibserver                      ClusterIP      10.152.183.253   <none>        80/TCP          33h
 snmp-redis-master                   ClusterIP      10.152.183.135   <none>        6379/TCP        33h

--- a/docs/troubleshooting/traps-issues.md
+++ b/docs/troubleshooting/traps-issues.md
@@ -11,7 +11,7 @@ microk8s kubectl -n sc4snmp get services
 This command should output similar data:
 ```
 NAME                                TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)         AGE
-snmp-redis-headless                 ClusterIP      None             <none>           6379/TCP        113s
+snmp-redis-master                 ClusterIP      None             <none>           6379/TCP        113s
 snmp-mibserver                      ClusterIP      10.152.183.163   <none>           80/TCP          113s
 snmp-mongodb                        ClusterIP      10.152.183.118   <none>           27017/TCP       113s
 snmp-redis-master                   ClusterIP      10.152.183.61    <none>           6379/TCP        113s

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -29,11 +29,11 @@ spec:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
           - name: REDIS_URL
-            value: redis://release-name-redis-headless:6379/1
+            value: redis://release-name-redis-master:6379/1
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-headless:6379/0
+            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -45,9 +45,9 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -29,11 +29,11 @@ spec:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
           - name: REDIS_URL
-            value: redis://release-name-redis-headless:6379/1
+            value: redis://release-name-redis-master:6379/1
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-headless:6379/0
+            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -45,9 +45,9 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -29,11 +29,11 @@ spec:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
           - name: REDIS_URL
-            value: redis://release-name-redis-headless:6379/1
+            value: redis://release-name-redis-master:6379/1
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-headless:6379/0
+            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -45,9 +45,9 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -29,11 +29,11 @@ spec:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
           - name: REDIS_URL
-            value: redis://release-name-redis-headless:6379/1
+            value: redis://release-name-redis-master:6379/1
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-headless:6379/0
+            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -45,9 +45,9 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/configmap-backend.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/configmap-backend.yaml
@@ -36,11 +36,11 @@ data:
               - name: CONFIG_PATH
                 value: /app/config/config.yaml
               - name: REDIS_URL
-                value: redis://release-name-redis-headless:6379/1
+                value: redis://release-name-redis-master:6379/1
               - name: INVENTORY_PATH
                 value: /app/inventory/inventory.csv
               - name: CELERY_BROKER_URL
-                value: redis://release-name-redis-headless:6379/0
+                value: redis://release-name-redis-master:6379/0
               - name: MONGO_URI
                 value: mongodb://release-name-mongodb:27017
               - name: MIB_SOURCES

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
@@ -25,13 +25,13 @@ spec:
         - name: MONGO_URI
           value: mongodb://release-name-mongodb:27017
         - name: REDIS_URL
-          value: redis://release-name-redis-headless:6379/3
+          value: redis://release-name-redis-master:6379/3
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
           value: sc4snmp
         - name: CELERY_BROKER_URL
-          value: redis://release-name-redis-headless:6379/2
+          value: redis://release-name-redis-master:6379/2
         - name: VALUES_DIRECTORY
           value: /var/values_dir
         ports:

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
@@ -45,13 +45,13 @@ spec:
         - name: MONGO_URI
           value: mongodb://release-name-mongodb:27017
         - name: REDIS_URL
-          value: redis://release-name-redis-headless:6379/3
+          value: redis://release-name-redis-master:6379/3
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
           value: sc4snmp
         - name: CELERY_BROKER_URL
-          value: redis://release-name-redis-headless:6379/2
+          value: redis://release-name-redis-master:6379/2
         - name: VALUES_DIRECTORY
           value: /var/values_dir
         - name: VALUES_FILE

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -29,11 +29,11 @@ spec:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
           - name: REDIS_URL
-            value: redis://release-name-redis-headless:6379/1
+            value: redis://release-name-redis-master:6379/1
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-headless:6379/0
+            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -45,9 +45,9 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -29,11 +29,11 @@ spec:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
           - name: REDIS_URL
-            value: redis://release-name-redis-headless:6379/1
+            value: redis://release-name-redis-master:6379/1
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-headless:6379/0
+            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -45,9 +45,9 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
             - name: REDIS_URL
-              value: redis://release-name-redis-headless:6379/1
+              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
             - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-headless:6379/0
+              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL


### PR DESCRIPTION
# Description

The `redis-headless-service` doesn't necessarily always works okay on multinode environment. 
As for now we use `redis` in `standalone` mode, therefore using `headless` is not required because:

1. headless services don’t route traffic — they just return a list of pod IPs
2. instead of load-balancing across pods, a headless service exposes the DNS records of each individual pod directly
3. Redis clients must handle this themselves. In standalone, clients expect a single, stable endpoint

It would seem logical to me that headless service with a single pod should always return only one ip address, therefore it should work fine - but apparently not. If the pod is not ready yet, restarting, failing a probe or scheduled on a node with network issues it will fail and looks like sometimes it might happen randomly.

Additonally this works correctly with using redis sentinel (helpful when one node fails, it provides read-only replicas so the system can survive short outage) with following config:

```
redis:
  architecture: replication
  replica:
    replicaCount: 2
  sentinel:
    enabled: true
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Refactor/improvement

## How Has This Been Tested?

Manual test, will run integration.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings