### PR TITLE
fix: Fixed the sim pod creation issue when sim.secret.name was set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - migrate MongoDB subchart to 15.6.26
 
 ### Fixed
+- Ensured `.Vaues.secret.name` is used during secret creation to prevent mismatched secret references in deployments
 
 
 ## [1.12.2]

--- a/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
+++ b/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-name: {{ include "splunk-connect-for-snmp.sim.secret" . }}
+  name: {{ include "splunk-connect-for-snmp.sim.secret" . }}
 type: Opaque
 data:
   signalfxToken: {{ .Values.sim.signalfxToken | b64enc | quote }}

--- a/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
+++ b/charts/splunk-connect-for-snmp/templates/common/sim-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "splunk-connect-for-snmp.name" . }}-sim
+name: {{ include "splunk-connect-for-snmp.sim.secret" . }}
 type: Opaque
 data:
   signalfxToken: {{ .Values.sim.signalfxToken | b64enc | quote }}


### PR DESCRIPTION
# Description

Issue:
This issue occurs when both .Values.secret.create and .[Values.secret.name](http://values.secret.name/) are set in the Helm values.
The problem arises because during the secret creation process, the value of .[Values.secret.name](http://values.secret.name/) is not being considered — the secret is created with a default name. However, when the deployment tries to reference the secret, it uses the name from .[Values.secret.name](http://values.secret.name/) (if it's set).
As a result, the deployment references a secret that doesn't exist, which leads to the pod failing to start with a CreateContainerConfigError.
To avoid this issue, we need to ensure that if .[Values.secret.name](http://values.secret.name/) is set, it's also used during secret creation.

Fixes # (issue)

## Type of change

- [x] Bug fix

## How Has This Been Tested?

Manual testing

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings