### PR TITLE
fix: update mibserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 - update MongoDB docker image to 7.0.14 for SC4SNMP docker installation
 
 ### Fixed
-- Ensured `.Vaues.secret.name` is used during secret creation to prevent mismatched secret references in deployments
+- Ensured `.Values.secret.name` is used during secret creation to prevent mismatched secret references in deployments
 - lack of `externalTrafficPolicy` in `values.schema.json`
+- update `mibserver` to 1.15.21 to fix problems with rendering pvc in case of local mibs compilation
 
 
 ## [1.12.2]

--- a/charts/splunk-connect-for-snmp/Chart.lock
+++ b/charts/splunk-connect-for-snmp/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 20.2.2
 - name: mibserver
   repository: https://pysnmp.github.io/mibs/charts/
-  version: 1.15.18
-digest: sha256:64bdee405118b51b47588ca86fada284233e4beb19c7539635dd833c706e1b4d
-generated: "2025-05-21T14:10:06.503084+02:00"
+  version: 1.15.20
+digest: sha256:474db1ae2ba03517cd54912232696aa6fc36d6d99738e0cb029e3eab0d4d8ffb
+generated: "2025-06-02T13:26:49.858342+02:00"

--- a/charts/splunk-connect-for-snmp/Chart.lock
+++ b/charts/splunk-connect-for-snmp/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 20.2.2
 - name: mibserver
   repository: https://pysnmp.github.io/mibs/charts/
-  version: 1.15.20
-digest: sha256:474db1ae2ba03517cd54912232696aa6fc36d6d99738e0cb029e3eab0d4d8ffb
-generated: "2025-06-02T13:26:49.858342+02:00"
+  version: 1.15.21
+digest: sha256:389e85827643b1799c9a08abe987403eeb5965bd0f1567339e4975f0460c78d3
+generated: "2025-06-03T15:48:49.0332+02:00"


### PR DESCRIPTION
# Description

In `1.15.20` version of the mibserver we changed the way templates are being rendered, we need to update the Chart.lock, as overriding image tag is not enough in this case.

Fixes # (issue) Linked to: https://github.com/splunk/splunk-connect-for-snmp/issues/1193

## Type of change

Please delete options that are not relevant.

- [x] Dependency update

## How Has This Been Tested?

N/A

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings