### PR TITLE
chore: add missing sudo

### DIFF
--- a/integration_tests/automatic_setup_microk8s.sh
+++ b/integration_tests/automatic_setup_microk8s.sh
@@ -120,7 +120,7 @@ yes $(hostname -I | cut -d " " -f1)/32 | sudo microk8s enable metallb
 sudo microk8s status --wait-ready
 
 cd ../charts/splunk-connect-for-snmp
-microk8s helm3 dep update
+sudo microk8s helm3 dep update
 cd ../../integration_tests
 
 echo $(green "Installing SC4SNMP on Kubernetes")


### PR DESCRIPTION
# Description

There was a new problem with integration tests pipeline:

```
Error: couldn't load repositories file (/home/runner/.config/helm/repositories.yaml): open /home/runner/.config/helm/repositories.yaml: permission denied
Installing SC4SNMP on Kubernetes
Error: INSTALLATION FAILED: An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies: found in Chart.yaml, but missing in charts/ directory: mongodb, redis, mibserver
```

Looks like we're missing sudo in `helm dep update` and the problem is related with that

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] Bug fix

## How Has This Been Tested?

integration tests

## Checklist

N/A