### PR TITLE
fix: add flag for ipv6 poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - fix text SNMP values with numbers and 'E' being interpreted as scientific notation
+- added missing `ipv6Enabled` flag in poller
 
 
 ## [1.12.3]

--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -181,6 +181,8 @@ Common labels
   value: {{ .Values.worker.poller.concurrency | default "4" | quote }}
 - name: PREFETCH_COUNT
   value: {{ .Values.worker.poller.prefetch | default "1" | quote }}
+- name: IPv6_ENABLED
+  value: {{ .Values.poller.ipv6Enabled | default "false" | quote }}
 {{- end }}
 
 {{- define "environmental-variables-sender" -}}

--- a/charts/splunk-connect-for-snmp/values.schema.json
+++ b/charts/splunk-connect-for-snmp/values.schema.json
@@ -371,6 +371,9 @@
         "logLevel": {
           "type": "string"
         },
+        "ipv6Enabled": {
+          "type": "boolean"
+        },
         "enableFullWalk": {
           "type": "boolean"
         }

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -258,6 +258,7 @@ poller:
   #  example_group_1,,2c,public,,,3000,static_profile,t,
   logLevel: "INFO"
 
+  ipv6Enabled: false
 worker:
   # workers are responsible for the actual execution of polling, processing trap messages, and sending data to Splunk.
   # More: https://splunk.github.io/splunk-connect-for-snmp/main/microk8s/configuration/worker-configuration/

--- a/docs/microk8s/configuration/values-params-description.md
+++ b/docs/microk8s/configuration/values-params-description.md
@@ -98,6 +98,8 @@ Detailed documentation about configuring poller can be found in [Poller](poller-
 | `splunkMetricNameHyphenToUnderscore` | Replaces hyphens with underscores in generated metric names to ensure compatibility with Splunk's metric schema | `false` |
 | `pollBaseProfiles`                   | Enables polling base profiles                                                                                   | `true`  |
 | `maxOidToProcess`                    | Maximum number of OIDs requested from SNMP Agent at once                                                        | `70`    |
+| `ipv6Enabled`                        | Enables polling for IPv6 addresses                                                                              | `false` |
+| `enableFullWalk`                     | Enables full walk of OIDs from device                                                                           | `false` |
 | `usernameSecrets`                    | List of kubernetes secrets name that will be used for polling                                                   |         |
 | `inventory`                          | List of configuration for polling                                                                               |         |
 | `logLevel`                           | Log level for a poller pod                                                                                      | `INFO`  |

--- a/docs/microk8s/enable-ipv6.md
+++ b/docs/microk8s/enable-ipv6.md
@@ -63,3 +63,9 @@ traps:
   ipFamilyPolicy: RequireDualStack
   ipFamilies: ["IPv4", "IPv6"]
 ```
+
+To configure poller to poll IPv4 and IPv6 addresses, you need to add the following configuration to the `values.yaml` file:
+``` 
+poller:
+  ipv6Enabled: true
+```

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -109,6 +109,8 @@ spec:
               value: "4"
             - name: PREFETCH_COUNT
               value: "1"
+            - name: IPv6_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -108,6 +108,8 @@ spec:
               value: "4"
             - name: PREFETCH_COUNT
               value: "1"
+            - name: IPv6_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -108,6 +108,8 @@ spec:
               value: "4"
             - name: PREFETCH_COUNT
               value: "1"
+            - name: IPv6_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -109,6 +109,8 @@ spec:
               value: "4"
             - name: PREFETCH_COUNT
               value: "1"
+            - name: IPv6_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -109,6 +109,8 @@ spec:
               value: "4"
             - name: PREFETCH_COUNT
               value: "1"
+            - name: IPv6_ENABLED
+              value: "false"
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -109,6 +109,8 @@ spec:
               value: "4"
             - name: PREFETCH_COUNT
               value: "1"
+            - name: IPv6_ENABLED
+              value: "false"
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
# Description

Add flag `ipv6Enabled` to enable ipv6 polling for kubernetes deployment.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

manual test

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings