### PR TITLE
chore: fix license accept issue in integration tests 

### DIFF
--- a/integration_tests/automatic_setup_compose.sh
+++ b/integration_tests/automatic_setup_compose.sh
@@ -89,7 +89,7 @@ sudo docker build -t snmp-local .
 
 sudo docker pull splunk/splunk:latest
 echo $(green "Running Splunk in Docker")
-sudo docker run -d -p 8000:8000 -p 8088:8088 -p 8089:8089 -e SPLUNK_START_ARGS='--accept-license' -e SPLUNK_PASSWORD='changeme2' splunk/splunk:latest
+sudo docker run -d -p 8000:8000 -p 8088:8088 -p 8089:8089 -e SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com -e SPLUNK_START_ARGS='--accept-license' -e SPLUNK_PASSWORD='changeme2' splunk/splunk:latest
 
 wait_for_splunk
 

--- a/integration_tests/automatic_setup_microk8s.sh
+++ b/integration_tests/automatic_setup_microk8s.sh
@@ -90,7 +90,7 @@ sudo microk8s ctr image import myimage.tar
 
 sudo docker pull splunk/splunk:latest
 echo $(green "Running Splunk in Docker")
-sudo docker run -d -p 8000:8000 -p 8088:8088 -p 8089:8089 -e SPLUNK_START_ARGS='--accept-license' -e SPLUNK_PASSWORD='changeme2' splunk/splunk:latest
+sudo docker run -d -p 8000:8000 -p 8088:8088 -p 8089:8089 -e SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com  -e SPLUNK_START_ARGS='--accept-license' -e SPLUNK_PASSWORD='changeme2' splunk/splunk:latest
 
 wait_for_splunk
 


### PR DESCRIPTION
# Description

There is an issue in integration tests, as running `splunk:latest` as we did before creates an infinite loop of `Waiting for Splunk`: https://github.com/splunk/splunk-connect-for-snmp/actions/runs/16875425784/job/47798790744?pr=1223

It is because the newest splunk image returns such a warning:

```
License not accepted, please adjust SPLUNK_GENERAL_TERMS and/or SPLUNK_START_ARGS to indicate you have accepted the current/latest version of the license.
The license you are accepting is the current/latest version of the Splunk General Terms, available here: https://www.splunk.com/en_us/legal/splunk-general-terms.html, as may be updated from time to time.
Unless you have jointly executed with Splunk a negotiated version of these General Terms that explicitly supersedes this agreement, by accessing or using Splunk software, you are agreeing to the Splunk General Terms posted at the time of your access and use and acknowledging its applicability to the Splunk software.
Please read and make sure you agree to the Splunk General Terms before you access or use this software.
Only after doing so should you include the '--accept-sgt-current-at-splunk-com' and '--accept-license' flags to indicate your acceptance of the Splunk General Terms and launch this software.
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Integration tests

## Checklist

N/A