### PR TITLE
Fixed CI/CD pipline failure due to migration of bitnami to bitna…

### DIFF
--- a/get_yaml_fields.py
+++ b/get_yaml_fields.py
@@ -20,6 +20,8 @@ if os.path.isfile(args.path):
             wrong_key = True
             break
     if not wrong_key:
+        if value.startswith('bitnami/') and args.variable == "image.repository":
+            value = value.replace('bitnami/', 'bitnamilegacy/')
         print(value)
     else:
         print("")


### PR DESCRIPTION

# Description

Fixed CI/CD pipline failure in pulling images for MongoDB and Redis from the Bitnami charts.

Fixes # (issue)
In the create_package.py script, the images for MongoDB and Redis are pulled from the Bitnami charts. However, in the corresponding values.yaml file, the repository is set to bitnami instead of bitnamilegacy. Since this values.yaml is being used, the images fail to pull correctly.
Fixed the issue by overwriting repository to bitnamilegacy from bitnami. 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix

## How Has This Been Tested?

Tested locally

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings