### PR TITLE
fix: Fixed CI/CD pipline failure due to migration of bitnami repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Unreleased
-- update MongoDB and Redis image sources from bitnami to bitnamilegacy repository to resolve CI/CD "offline-installation" failure
 
 ### Changed
 - add CounterBasedGauge64 and ZeroBasedCounter64 as metrics types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Updated MongoDB and Redis image sources from bitnami to bitnamilegacy repository to resolve CI/CD "offline-installation" failure
+- update MongoDB and Redis image sources from bitnami to bitnamilegacy repository to resolve CI/CD "offline-installation" failure
 
 ### Changed
 - add CounterBasedGauge64 and ZeroBasedCounter64 as metrics types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated MongoDB and Redis image sources from bitnami to bitnamilegacy repository to resolve CI/CD "offline-installation" failure
 
 ### Changed
 - add CounterBasedGauge64 and ZeroBasedCounter64 as metrics types

--- a/get_yaml_fields.py
+++ b/get_yaml_fields.py
@@ -20,6 +20,8 @@ if os.path.isfile(args.path):
             wrong_key = True
             break
     if not wrong_key:
+        if value.startswith("bitnami/") and args.variable == "image.repository":
+            value = value.replace("bitnami/", "bitnamilegacy/")
         print(value)
     else:
         print("")

--- a/get_yaml_fields.py
+++ b/get_yaml_fields.py
@@ -20,7 +20,7 @@ if os.path.isfile(args.path):
             wrong_key = True
             break
     if not wrong_key:
-        if value.startswith("bitnami/") and args.variable == "image.repository":
+        if value.startswith("bitnami/"):
             value = value.replace("bitnami/", "bitnamilegacy/")
         print(value)
     else:


### PR DESCRIPTION
# Description

The bitnami charts are still pointing to the bitnami repo, so raising this pr to change the repository to bitnamilegacy.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

## How Has This Been Tested?

Tested locally

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR