### PR TITLE
docs: add disclaimer for o11y

### DIFF
--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -108,7 +108,6 @@ sim:
 
   # WARNING:
   # The Splunk Observability Cloud integration (`sim`) is experimental. Effective use depends on well‑curated SNMP profiles whose metric names, types, and dimensions align with Splunk Observability data model expectations. Profiles not tailored may produce superfluous metrics. Validate and refine profiles in controlled environments before enabling sim.enabled: true for broader use; otherwise keep it disabled. Future releases may change configuration behavior.
-  # Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
   # In order to use it, you must set `enabled` flag in `values.yaml` to `true`
   enabled: false
   # Splunk Observability org access token.

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -105,6 +105,11 @@ splunk:
 
 sim:
   # Enables sending data to Splunk Observability/SignalFx.
+
+  # WARNING:
+  # The Splunk Observability Cloud integration (`sim`) is experimental. Effective use depends on well‑curated SNMP profiles whose metric names, types, and dimensions align with Splunk Observability data model expectations. Profiles not tailored may produce superfluous metrics. Validate and refine profiles in controlled environments before enabling sim.enabled: true for broader use; otherwise keep it disabled. Future releases may change configuration behavior.
+  # Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
+  # In order to use it, you must set `enabled` flag in `values.yaml` to `true`
   enabled: false
   # Splunk Observability org access token.
   # Required for Splunk Observability (if `realm` is specified).

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -21,7 +21,7 @@ show the status of SC4SNMP tasks.
 !!! info
     Dashboard is compatible starting from version **1.11.0** and requires the `logLevel` set at least to **INFO**.
 
-1. [Create metrics index](microk8s/splunk-requirements.md#requirements-for-splunk-enterprise-or-enterprise-cloud) in Splunk.
+1. [Create metrics index](splunk-requirements.md#requirements-for-splunk-enterprise-or-enterprise-cloud) in Splunk.
 2. Enable metrics logging for your runtime:
     * For Kubernetes install [Splunk OpenTelemetry Collector for K8S](microk8s/sck-installation.md)
     * For Docker Compose use [Splunk logging driver for docker](dockercompose/9-splunk-logging.md)

--- a/docs/microk8s/configuration/sim-configuration.md
+++ b/docs/microk8s/configuration/sim-configuration.md
@@ -1,11 +1,13 @@
 # OTEL and Splunk Observability Cloud configuration
 
-Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
-In order to use it, you must set `enabled` flag in `values.yaml` to `true`:
+!!!warning 
+    The Splunk Observability Cloud integration (`sim`) is experimental. Effective use depends on well‑curated SNMP profiles whose metric names, types, and dimensions align with Splunk Observability data model expectations. Profiles not tailored may produce superfluous metrics. Validate and refine profiles in controlled environments before enabling sim.enabled: true for broader use; otherwise keep it disabled. Future releases may change configuration behavior.
+    Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
+    In order to use it, you must set `enabled` flag in `values.yaml` to `true`:
 
 ```yaml
 sim:
-  # sim must be enabled if you want to use SignalFx
+  # sim must be enabled if you want to use Splunk Observability Cloud
   enabled: true
 ```
 

--- a/docs/microk8s/configuration/sim-configuration.md
+++ b/docs/microk8s/configuration/sim-configuration.md
@@ -3,7 +3,6 @@
 !!!warning 
     The Splunk Observability Cloud integration (`sim`) is experimental. Effective use depends on well‑curated SNMP profiles whose metric names, types, and dimensions align with Splunk Observability data model expectations. Profiles not tailored may produce superfluous metrics. Validate and refine profiles in controlled environments before enabling sim.enabled: true for broader use; otherwise keep it disabled. Future releases may change configuration behavior.
     Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
-    In order to use it, you must set `enabled` flag in `values.yaml` to `true`:
 
 ```yaml
 sim:

--- a/docs/microk8s/configuration/values-params-description.md
+++ b/docs/microk8s/configuration/values-params-description.md
@@ -50,7 +50,6 @@ Detailed documentation about configuring sim can be found in [Splunk Infrastruct
 !!!warning 
     The Splunk Observability Cloud integration (`sim`) is experimental. Effective use depends on well‑curated SNMP profiles whose metric names, types, and dimensions align with Splunk Observability data model expectations. Profiles not tailored may produce superfluous metrics. Validate and refine profiles in controlled environments before enabling sim.enabled: true for broader use; otherwise keep it disabled. Future releases may change configuration behavior.
     Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
-    In order to use it, you must set `enabled` flag in `values.yaml` to `true`
 
 
 | Variable                                        | Description                                                                                                                     | Default |

--- a/docs/microk8s/configuration/values-params-description.md
+++ b/docs/microk8s/configuration/values-params-description.md
@@ -47,6 +47,12 @@ Detailed documentation about configuring UI can be found in [Enable GUI](../gui/
 
 Detailed documentation about configuring sim can be found in [Splunk Infrastructure Monitoring](sim-configuration.md).
 
+!!!warning 
+    The Splunk Observability Cloud integration (`sim`) is experimental. Effective use depends on well‑curated SNMP profiles whose metric names, types, and dimensions align with Splunk Observability data model expectations. Profiles not tailored may produce superfluous metrics. Validate and refine profiles in controlled environments before enabling sim.enabled: true for broader use; otherwise keep it disabled. Future releases may change configuration behavior.
+    Splunk OpenTelemetry Collector is a component that provides an option to send metrics to Splunk Observability Cloud.
+    In order to use it, you must set `enabled` flag in `values.yaml` to `true`
+
+
 | Variable                                        | Description                                                                                                                     | Default |
 |-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|---------|
 | `enabled`                                       | Enables sending data to Splunk Observability Cloud/ SignalFx                                                                    | `false` |

--- a/docs/microk8s/splunk-requirements.md
+++ b/docs/microk8s/splunk-requirements.md
@@ -21,7 +21,10 @@ See the following prerequisites for the Splunk Connect for SNMP.
 4. Use the shared IP address for SNMP traps. Simple and POC deployments will use the same IP address as the host server. For an HA deployment, use the management interface and the IP address of each cluster member. 
 5. Obtain the IP address of an internal DNS server that can resolve the Splunk Endpoint.
 
-### Requirements (Splunk Infrastructure Monitoring)
+### Requirements for Splunk Infrastructure Monitoring
+
+!!!warning 
+    The Splunk Observability Cloud integration is experimental. Effective use depends on well‑curated SNMP profiles whose metric names, types, and dimensions align with Splunk Observability data model expectations. Profiles not tailored may produce superfluous metrics. Future releases may change configuration behavior.
 
 Obtain the following from your Splunk Observability Cloud environment:
 

--- a/docs/splunk-requirements.md
+++ b/docs/splunk-requirements.md
@@ -14,7 +14,7 @@ See the following prerequisites for the Splunk Connect for SNMP.
        * netops (event type)
    
 > **_Note:_** `netmetrics` and `netops` are the default names of SC4SNMP indexes. You can use the index names of your choice and
-> reference it in the `values.yaml` file later on. See [SC4SNMP Parameters](sc4snmp-installation.md#configure-splunk-enterprise-or-splunk-cloud-connection) for details.
+> reference it in the `values.yaml` file later on. See [SC4SNMP Parameters](microk8s/sc4snmp-installation.md#configure-splunk-enterprise-or-splunk-cloud-connection) for details.
 
 2. Create or obtain a new Splunk HTTP Event Collector token and the correct HTTPS endpoint.
 3. Verify the token using [curl](https://docs.splunk.com/Documentation/Splunk/8.1.3/Data/FormateventsforHTTPEventCollector). The endpoint must use a publicly trusted certificate authority.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - High-level design: "architecture/design.md"
       - Infrastructure Planning: "architecture/planning.md"
   - Getting Started with Docker Compose:
+      - Splunk Requirements: "microk8s/splunk-requirements.md"
       - Install Docker: "dockercompose/1-install-docker.md"
       - Download package: "dockercompose/2-download-package.md"
       - Inventory configuration: "dockercompose/3-inventory-configuration.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ nav:
       - High-level design: "architecture/design.md"
       - Infrastructure Planning: "architecture/planning.md"
   - Getting Started with Docker Compose:
-      - Splunk Requirements: "microk8s/splunk-requirements.md"
+      - Splunk Requirements: "splunk-requirements.md"
       - Install Docker: "dockercompose/1-install-docker.md"
       - Download package: "dockercompose/2-download-package.md"
       - Inventory configuration: "dockercompose/3-inventory-configuration.md"
@@ -58,7 +58,7 @@ nav:
       - Enable IPv6: "dockercompose/10-enable-ipv6.md"
   - Getting Started with Microk8s:
       - Installation:
-        - Splunk Requirements: "microk8s/splunk-requirements.md"
+        - Splunk Requirements: "splunk-requirements.md"
         - Platform Microk8s: "microk8s/mk8s/k8s-microk8s.md"
         - Install Splunk OpenTelemetry Collector for Kubernetes: "microk8s/sck-installation.md"
         - Install SC4SNMP: "microk8s/sc4snmp-installation.md"


### PR DESCRIPTION
# Description

Introduces an explicit experimental disclaimer for the Splunk Observability integration and documents/testing guidance.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

N/A

## Checklist

N/A