### PR TITLE
chore: add small walk to conditional profiles in integration tests

### DIFF
--- a/charts/splunk-connect-for-snmp/Chart.yaml
+++ b/charts/splunk-connect-for-snmp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-connect-for-snmp
-description: A Helm chart for SNMP Connect for SNMP
+description: A Helm chart for Splunk Connect for SNMP
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/integration_tests/test_poller_integration.py
+++ b/integration_tests/test_poller_integration.py
@@ -980,6 +980,10 @@ def setup_single_gt_and_lt_profiles(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "gt_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1000,7 +1004,7 @@ def setup_single_gt_and_lt_profiles(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,gt_profile;lt_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1008,7 +1012,7 @@ def setup_single_gt_and_lt_profiles(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,gt_profile;lt_profile,,"]
+            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,"]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1016,14 +1020,14 @@ def setup_single_gt_and_lt_profiles(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,gt_profile;lt_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,t",
             ],
             "inventory.yaml",
         )
         upgrade_helm_microk8s(["inventory.yaml"])
     else:
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,gt_profile;lt_profile,,t"]
+            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,t"]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1064,6 +1068,10 @@ def setup_single_in_and_equals_profiles(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "in_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1092,7 +1100,7 @@ def setup_single_in_and_equals_profiles(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,in_profile;equals_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1100,7 +1108,7 @@ def setup_single_in_and_equals_profiles(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,in_profile;equals_profile,,"]
+            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,"]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1108,14 +1116,14 @@ def setup_single_in_and_equals_profiles(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,in_profile;equals_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,t",
             ],
             "inventory.yaml",
         )
         upgrade_helm_microk8s(["inventory.yaml"])
     else:
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,in_profile;equals_profile,,t"]
+            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,t"]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1158,6 +1166,10 @@ def setup_single_regex_and_options_profiles(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "regex_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1185,7 +1197,7 @@ def setup_single_regex_and_options_profiles(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,regex_profile;options_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;regex_profile;options_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1193,7 +1205,7 @@ def setup_single_regex_and_options_profiles(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,regex_profile;options_profile,,"]
+            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;regex_profile;options_profile,,"]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1201,7 +1213,7 @@ def setup_single_regex_and_options_profiles(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,regex_profile;options_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;regex_profile;options_profile,,t",
             ],
             "inventory.yaml",
         )
@@ -1209,7 +1221,7 @@ def setup_single_regex_and_options_profiles(request):
     else:
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,regex_profile;options_profile,,t"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;regex_profile;options_profile,,t"
             ]
         )
         upgrade_docker_compose()
@@ -1255,6 +1267,10 @@ def setup_single_gt_and_lt_profiles_with_negation(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "not_gt_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1285,7 +1301,7 @@ def setup_single_gt_and_lt_profiles_with_negation(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_gt_profile;not_lt_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_gt_profile;not_lt_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1293,7 +1309,7 @@ def setup_single_gt_and_lt_profiles_with_negation(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,not_gt_profile;not_lt_profile,,"]
+            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_gt_profile;not_lt_profile,,"]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1301,7 +1317,7 @@ def setup_single_gt_and_lt_profiles_with_negation(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_gt_profile;not_lt_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_gt_profile;not_lt_profile,,t",
             ],
             "inventory.yaml",
         )
@@ -1309,7 +1325,7 @@ def setup_single_gt_and_lt_profiles_with_negation(request):
     else:
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_gt_profile;not_lt_profile,,t"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_gt_profile;not_lt_profile,,t"
             ]
         )
         upgrade_docker_compose()
@@ -1355,6 +1371,10 @@ def setup_single_in_and_equals_profiles_with_negation(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "not_in_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1385,7 +1405,7 @@ def setup_single_in_and_equals_profiles_with_negation(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_in_profile;not_equals_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_in_profile;not_equals_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1394,7 +1414,7 @@ def setup_single_in_and_equals_profiles_with_negation(request):
         update_profiles_compose(profiles)
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_in_profile;not_equals_profile,,"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_in_profile;not_equals_profile,,"
             ]
         )
         upgrade_docker_compose()
@@ -1403,7 +1423,7 @@ def setup_single_in_and_equals_profiles_with_negation(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_in_profile;not_equals_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_in_profile;not_equals_profile,,t",
             ],
             "inventory.yaml",
         )
@@ -1411,7 +1431,7 @@ def setup_single_in_and_equals_profiles_with_negation(request):
     else:
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_in_profile;not_equals_profile,,t"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_in_profile;not_equals_profile,,t"
             ]
         )
         upgrade_docker_compose()
@@ -1457,6 +1477,10 @@ def setup_single_regex_and_options_profiles_with_negation(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "not_regex_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1487,7 +1511,7 @@ def setup_single_regex_and_options_profiles_with_negation(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_regex_profile;not_options_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_regex_profile;not_options_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1496,7 +1520,7 @@ def setup_single_regex_and_options_profiles_with_negation(request):
         update_profiles_compose(profiles)
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_regex_profile;not_options_profile,,"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_regex_profile;not_options_profile,,"
             ]
         )
         upgrade_docker_compose()
@@ -1505,7 +1529,7 @@ def setup_single_regex_and_options_profiles_with_negation(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_regex_profile;not_options_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_regex_profile;not_options_profile,,t",
             ],
             "inventory.yaml",
         )
@@ -1513,7 +1537,7 @@ def setup_single_regex_and_options_profiles_with_negation(request):
     else:
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,not_regex_profile;not_options_profile,,t"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_regex_profile;not_options_profile,,t"
             ]
         )
         upgrade_docker_compose()
@@ -1563,6 +1587,10 @@ def setup_multiple_conditions_profiles(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "gt_and_equals_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1593,7 +1621,7 @@ def setup_multiple_conditions_profiles(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,gt_and_equals_profile;lt_and_in_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_and_equals_profile;lt_and_in_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1602,7 +1630,7 @@ def setup_multiple_conditions_profiles(request):
         update_profiles_compose(profiles)
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,gt_and_equals_profile;lt_and_in_profile,,"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_and_equals_profile;lt_and_in_profile,,"
             ]
         )
         upgrade_docker_compose()
@@ -1611,7 +1639,7 @@ def setup_multiple_conditions_profiles(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,gt_and_equals_profile;lt_and_in_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_and_equals_profile;lt_and_in_profile,,t",
             ],
             "inventory.yaml",
         )
@@ -1619,7 +1647,7 @@ def setup_multiple_conditions_profiles(request):
     else:
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,gt_and_equals_profile;lt_and_in_profile,,t"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_and_equals_profile;lt_and_in_profile,,t"
             ]
         )
         upgrade_docker_compose()
@@ -1668,6 +1696,10 @@ def setup_wrong_conditions_profiles(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "wrong_gt_and_equals_profile": {
             "frequency": 7,
             "varBinds": [yaml_escape_list(sq("IF-MIB"), sq("ifOutDiscards"))],
@@ -1705,7 +1737,7 @@ def setup_wrong_conditions_profiles(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1714,7 +1746,7 @@ def setup_wrong_conditions_profiles(request):
         update_profiles_compose(profiles)
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,"
             ]
         )
         upgrade_docker_compose()
@@ -1723,7 +1755,7 @@ def setup_wrong_conditions_profiles(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,t",
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,t",
             ],
             "inventory.yaml",
         )
@@ -1731,7 +1763,7 @@ def setup_wrong_conditions_profiles(request):
     else:
         update_inventory_compose(
             [
-                f"{trap_external_ip},1166,2c,public,,,600,wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,t"
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;wrong_gt_and_equals_profile;wrong_lt_and_in_profile;wrong_equals_profile,,t"
             ]
         )
         upgrade_docker_compose()
@@ -1759,6 +1791,10 @@ def setup_misconfigured_profiles(request):
     trap_external_ip = request.config.getoption("trap_external_ip")
     deployment = request.config.getoption("sc4snmp_deployment")
     profiles = {
+        "small_walk": {
+            "varBinds": [yaml_escape_list(sq("IF-MIB"))],
+            "condition": {"type": "walk"},
+        },
         "no_varbinds_profile": {
             "frequency": 7,
             "varBinds": [],
@@ -1805,7 +1841,7 @@ def setup_misconfigured_profiles(request):
         update_profiles_microk8s(profiles)
         update_file_microk8s(
             [
-                f"{trap_external_ip},1165,2c,public,,,600,no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,",
+                f"{trap_external_ip},1165,2c,public,,,600,small_walk;no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,",
             ],
             "inventory.yaml",
         )
@@ -1814,7 +1850,7 @@ def setup_misconfigured_profiles(request):
         update_profiles_compose(profiles)
         update_inventory_compose(
             [
-                f"{trap_external_ip},1165,2c,public,,,600,no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,",
+                f"{trap_external_ip},1165,2c,public,,,600,small_walk;no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,",
             ]
         )
         upgrade_docker_compose()
@@ -1823,7 +1859,7 @@ def setup_misconfigured_profiles(request):
     if deployment == "microk8s":
         update_file_microk8s(
             [
-                f"{trap_external_ip},1165,2c,public,,,600,no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,t",
+                f"{trap_external_ip},1165,2c,public,,,600,small_walk;no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,t",
             ],
             "inventory.yaml",
         )
@@ -1831,7 +1867,7 @@ def setup_misconfigured_profiles(request):
     else:
         update_inventory_compose(
             [
-                f"{trap_external_ip},1165,2c,public,,,600,no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,t",
+                f"{trap_external_ip},1165,2c,public,,,600,small_walk;no_varbinds_profile;no_operation_key_in_condition_profile;no_frequency_profile;no_patterns_profile,,t",
             ]
         )
         upgrade_docker_compose()

--- a/integration_tests/test_poller_integration.py
+++ b/integration_tests/test_poller_integration.py
@@ -1012,7 +1012,9 @@ def setup_single_gt_and_lt_profiles(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,"]
+            [
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,"
+            ]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1027,7 +1029,9 @@ def setup_single_gt_and_lt_profiles(request):
         upgrade_helm_microk8s(["inventory.yaml"])
     else:
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,t"]
+            [
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;gt_profile;lt_profile,,t"
+            ]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1108,7 +1112,9 @@ def setup_single_in_and_equals_profiles(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,"]
+            [
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,"
+            ]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1123,7 +1129,9 @@ def setup_single_in_and_equals_profiles(request):
         upgrade_helm_microk8s(["inventory.yaml"])
     else:
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,t"]
+            [
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;in_profile;equals_profile,,t"
+            ]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1205,7 +1213,9 @@ def setup_single_regex_and_options_profiles(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;regex_profile;options_profile,,"]
+            [
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;regex_profile;options_profile,,"
+            ]
         )
         upgrade_docker_compose()
     time.sleep(120)
@@ -1309,7 +1319,9 @@ def setup_single_gt_and_lt_profiles_with_negation(request):
     else:
         update_profiles_compose(profiles)
         update_inventory_compose(
-            [f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_gt_profile;not_lt_profile,,"]
+            [
+                f"{trap_external_ip},1166,2c,public,,,600,small_walk;not_gt_profile;not_lt_profile,,"
+            ]
         )
         upgrade_docker_compose()
     time.sleep(120)


### PR DESCRIPTION
# Description

When we disabled a full walk by default, that might have caused conditional profiles integration tests to behave flaky.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

## How Has This Been Tested?

Integration tests

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings