### PR TITLE
fix: add HA templates and modify the code

### DIFF
--- a/.github/workflows/ci-ui-tests.yaml
+++ b/.github/workflows/ci-ui-tests.yaml
@@ -54,7 +54,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: false
           swap-storage: false
 

--- a/.github/workflows/ci-ui-tests.yaml
+++ b/.github/workflows/ci-ui-tests.yaml
@@ -48,6 +48,16 @@ jobs:
 
 
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
+
       - name: Checkout Project
         uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ FROM base AS final
 
 RUN mkdir /.pysnmp && chown 10001:10001 /.pysnmp
 RUN chown 10001:10001 /tmp
-USER 10001:10001
 COPY --from=builder /app/.venv /app/.venv
-COPY entrypoint.sh ./
-ENTRYPOINT ["./entrypoint.sh"]
+COPY entrypoint.sh /app/entrypoint.sh
+COPY construct-redis-url.sh /app/construct-redis-url.sh
+RUN chmod +x /app/construct-redis-url.sh /app/entrypoint.sh
+USER 10001:10001
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/charts/splunk-connect-for-snmp/templates/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/_helpers.tpl
@@ -100,7 +100,7 @@ Whether enable polling
 Generate Redis environment variables for application pods
 */ -}}
 {{- define "splunk-connect-for-snmp.redis-env" -}}
-{{- if eq .Values.redis.architecture "replication" }}
+{{- if eq .Values.redis.architecture "replication" -}}
 - name: REDIS_MODE
   value: "replication"
 - name: REDIS_SENTINEL_SERVICE
@@ -139,18 +139,18 @@ Generate Redis environment variables for application pods
       key: password
       {{- end }}
 {{- end -}}
-{{- end }}
+{{- end -}}
 
 {{- /*
 Generate Redis environment variables for application pods
 */ -}}
 {{- define "splunk-connect-for-snmp.redis-annotations" -}}
-{{- if eq .Values.redis.architecture "replication" }}
+{{- if eq .Values.redis.architecture "replication" -}}
 checksum/redis-config: {{ include (print $.Template.BasePath "/redis/redis-ha-config.yaml") . | sha256sum }}
 {{- else -}}
 checksum/redis-config: {{ include (print $.Template.BasePath "/redis/redis-config.yaml") . | sha256sum }}
-{{- end }}
+{{- end -}}
 {{- if .Values.redis.auth.enabled }}
 checksum/redis-secret: {{ include (print $.Template.BasePath "/redis/redis-secret.yaml") . | sha256sum }}
-{{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 }}
         {{- with .Values.inventory.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -9,11 +9,11 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-      {{- with .Values.inventory.podAnnotations }}
-      annotations:      
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-
+      annotations:
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
+        {{- with .Values.inventory.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "splunk-connect-for-snmp.inventory.selectorLabels" . | nindent 8 }}
     spec:
@@ -30,26 +30,7 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-        {{- if .Values.redis.auth.enabled }}
-          - name: REDIS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                {{- if .Values.redis.auth.existingSecret }}
-                name: {{ .Values.redis.auth.existingSecret }}
-                key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                {{- else }}
-                name: {{ .Release.Name }}-redis-secret
-                key: password
-                {{- end }}
-          {{- end }}
-          - name: REDIS_HOST
-            value: {{ .Release.Name }}-redis
-          - name: REDIS_PORT
-            value: "6379"
-          - name: REDIS_DB
-            value: "1"
-          - name: CELERY_DB
-            value: "0"
+          {{- include "splunk-connect-for-snmp.redis-env" . | nindent 10 }}
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: MONGO_URI

--- a/charts/splunk-connect-for-snmp/templates/redis/redis-ha-config.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/redis-ha-config.yaml
@@ -1,0 +1,32 @@
+{{- if eq .Values.redis.architecture "replication" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-redis-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-redis
+data:
+  redis.conf: |
+    dir /data
+
+    # Persistence
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    {{- if .Values.redis.persistence.aof.enabled }}
+    appendonly yes
+    appendfsync {{ .Values.redis.persistence.aof.fsync | default "everysec" }}
+    {{- end }}
+
+    # Replication
+    min-replicas-to-write 1
+    min-replicas-max-lag 10
+
+    loglevel notice
+    maxmemory-policy noeviction
+    bind 0.0.0.0
+    protected-mode no
+    port 6379
+{{- end }}

--- a/charts/splunk-connect-for-snmp/templates/redis/redis-ha-service.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/redis-ha-service.yaml
@@ -1,0 +1,32 @@
+{{- if eq .Values.redis.architecture "replication" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-redis
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: {{ .Release.Name }}-redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-redis
+spec:
+  clusterIP: None
+  ports:
+  - port: 6379
+    name: redis
+  selector:
+    app: {{ .Release.Name }}-redis
+{{- end }}

--- a/charts/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
@@ -1,16 +1,18 @@
-{{- if eq .Values.redis.architecture "standalone" }}
-{{- $bitnamiPVC := printf "redis-data-%s-redis-master-0" .Release.Name }}
-{{- $existingPVC := lookup "v1" "PersistentVolumeClaim" .Release.Namespace $bitnamiPVC }}
+{{- if eq .Values.redis.architecture "replication" }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-redis-standalone
+  name: {{ .Release.Name }}-redis-ha
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-redis
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: database
 spec:
-  serviceName: {{ .Release.Name }}-redis
-  replicas: 1
+  serviceName: {{ .Release.Name }}-redis-headless
+  replicas: {{ .Values.redis.replicas | default 3 }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: {{ .Release.Name }}-redis
@@ -26,6 +28,7 @@ spec:
         runAsUser: {{ .runAsUser }}
         fsGroup: {{ .fsGroup }}
       {{- end }}
+      {{- if .Values.redis.storage.enabled }}
       initContainers:
       - name: fix-permissions
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
@@ -34,22 +37,16 @@ spec:
         - sh
         - -c
         - |
-          echo "=== Redis Init: Fixing Permissions ==="
-          echo "Current ownership:"
-          ls -ln /data
-          echo ""
-          echo "Fixing ownership to {{ .Values.redis.podSecurityContext.runAsUser }}:{{ .Values.redis.podSecurityContext.fsGroup }}..."
+          echo "Fixing permissions on /data..."
           chown -R {{ .Values.redis.podSecurityContext.runAsUser }}:{{ .Values.redis.podSecurityContext.fsGroup }} /data
           chmod -R 755 /data
-          echo ""
-          echo "New ownership:"
           ls -ln /data
-          echo "=== Permissions Fixed ==="
         volumeMounts:
         - name: redis-data
           mountPath: /data
         securityContext:
-          runAsUser: 0  # Must run as root to chown
+          runAsUser: 0
+      {{- end }}
       containers:
       - name: redis
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
@@ -57,37 +54,58 @@ spec:
         ports:
         - containerPort: 6379
           name: redis
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- if .Values.redis.auth.enabled }}
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.redis.auth.existingSecret }}
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
+              {{- else }}
+              name: {{ .Release.Name }}-redis-secret
+              key: password
+              {{- end }}
+        {{- end }}
         command:
         - sh
         - -c
         args:
         - |
-          # Copy config to writable location
           cp /etc/redis/redis.conf /tmp/redis.conf
 
           {{- if .Values.redis.auth.enabled }}
-          # Append password at runtime
           echo "requirepass $REDIS_PASSWORD" >> /tmp/redis.conf
+          echo "masterauth $REDIS_PASSWORD" >> /tmp/redis.conf
           {{- end }}
 
+          # Announce pod IP for Sentinel
+          echo "replica-announce-ip $POD_IP" >> /tmp/redis.conf
+          echo "replica-announce-port 6379" >> /tmp/redis.conf
+
           # Start Redis
+          # Sentinel will handle promotion - all start as replicas initially
+          HOSTNAME=$(hostname)
+          MASTER_NAME="{{ .Release.Name }}-redis-ha-0"
+          MASTER_HOST="$MASTER_NAME.{{ .Release.Name }}-redis-headless"
+
+          if [ "$HOSTNAME" = "$MASTER_NAME" ]; then
+            echo "Starting as master"
+          else
+            echo "replicaof $MASTER_HOST 6379" >> /tmp/redis.conf
+            echo "Starting as replica of $MASTER_HOST"
+          fi
+
           exec redis-server /tmp/redis.conf
-        {{- if .Values.redis.auth.enabled }}
-        env:
-          - name: REDIS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                {{- if .Values.redis.auth.existingSecret }}
-                name: {{ .Values.redis.auth.existingSecret }}
-                key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                {{- else }}
-                name: {{ .Release.Name }}-redis-secret
-                key: password
-                {{- end }}
-        {{- end }}
         volumeMounts:
+        {{- if .Values.redis.storage.enabled }}
         - name: redis-data
           mountPath: /data
+        {{- end }}
         - name: redis-config
           mountPath: /etc/redis
         resources:
@@ -104,8 +122,10 @@ spec:
               {{- else }}
               redis-cli ping
               {{- end }}
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.redis.livenessProbe.initialDelaySeconds | default 30 }}
+          periodSeconds: {{ .Values.redis.livenessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.redis.livenessProbe.timeoutSeconds | default 5 }}
+          failureThreshold: {{ .Values.redis.livenessProbe.failureThreshold | default 3 }}
         {{- end }}
         {{- if .Values.redis.readinessProbe.enabled | default true }}
         readinessProbe:
@@ -119,35 +139,20 @@ spec:
               {{- else }}
               redis-cli ping
               {{- end }}
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: {{ .Values.redis.readinessProbe.initialDelaySeconds | default 5 }}
+          periodSeconds: {{ .Values.redis.readinessProbe.periodSeconds | default 5 }}
+          timeoutSeconds: {{ .Values.redis.readinessProbe.timeoutSeconds | default 3 }}
+          failureThreshold: {{ .Values.redis.readinessProbe.failureThreshold | default 3 }}
         {{- end }}
-      {{- if and .Values.redis.storage.enabled $existingPVC }}
-      # Reuse existing Bitnami PVC
-      volumes:
-      - name: redis-data
-        persistentVolumeClaim:
-          claimName: {{ $bitnamiPVC }}
-      - name: redis-config
-        configMap:
-          name: {{ .Release.Name }}-redis-config
-      {{- else if .Values.redis.storage.enabled }}
-      # Storage enabled but no existing PVC - use volumeClaimTemplates below
       volumes:
       - name: redis-config
         configMap:
           name: {{ .Release.Name }}-redis-config
-      {{- else }}
-      # Storage disabled - use emptyDir (ephemeral)
-      volumes:
+      {{- if not .Values.redis.storage.enabled }}
       - name: redis-data
         emptyDir: {}
-      - name: redis-config
-        configMap:
-          name: {{ .Release.Name }}-redis-config
       {{- end }}
-  {{- if and .Values.redis.storage.enabled (not $existingPVC) }}
-  # No existing PVC found, create new one via volumeClaimTemplates
+  {{- if .Values.redis.storage.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: redis-data

--- a/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-config.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-config.yaml
@@ -12,11 +12,11 @@ data:
     dir /data
     sentinel resolve-hostnames yes
     sentinel announce-hostnames yes
-    sentinel monitor mymaster {{ .Release.Name }}-redis-ha-0.{{ .Release.Name }}-redis-headless 6379 {{ .Values.redis.sentinel.quorum }}
+    sentinel monitor ${REDIS_MASTER_NAME} {{ .Release.Name }}-redis-ha-0.{{ .Release.Name }}-redis-headless 6379 {{ .Values.redis.sentinel.quorum }}
     {{- if .Values.redis.auth.enabled }}
-    sentinel auth-pass mymaster ${REDIS_PASSWORD}
+    sentinel auth-pass ${REDIS_MASTER_NAME} ${REDIS_PASSWORD}
     {{- end }}
-    sentinel down-after-milliseconds mymaster 5000
-    sentinel parallel-syncs mymaster 1
-    sentinel failover-timeout mymaster 10000
+    sentinel down-after-milliseconds ${REDIS_MASTER_NAME} 5000
+    sentinel parallel-syncs ${REDIS_MASTER_NAME} 1
+    sentinel failover-timeout ${REDIS_MASTER_NAME} 10000
 {{- end }}

--- a/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-config.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-config.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.redis.architecture "replication" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-redis-sentinel-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-redis-sentinel
+data:
+  sentinel.conf: |
+    port 26379
+    dir /data
+    sentinel resolve-hostnames yes
+    sentinel announce-hostnames yes
+    sentinel monitor mymaster {{ .Release.Name }}-redis-ha-0.{{ .Release.Name }}-redis-headless 6379 {{ .Values.redis.sentinel.quorum }}
+    {{- if .Values.redis.auth.enabled }}
+    sentinel auth-pass mymaster ${REDIS_PASSWORD}
+    {{- end }}
+    sentinel down-after-milliseconds mymaster 5000
+    sentinel parallel-syncs mymaster 1
+    sentinel failover-timeout mymaster 10000
+{{- end }}

--- a/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         args:
         - |
           cp /etc/redis/sentinel.conf /data/sentinel.conf
+          sed -i "s/\${REDIS_MASTER_NAME}/$REDIS_MASTER_NAME/g" /data/sentinel.conf
           {{- if .Values.redis.auth.enabled }}
           sed -i "s/\${REDIS_PASSWORD}/$REDIS_PASSWORD/g" /data/sentinel.conf
           {{- end }}
@@ -72,7 +73,7 @@ spec:
             command:
             - sh
             - -c
-            - redis-cli -p 26379 sentinel get-master-addr-by-name mymaster | grep snmp-redis-ha-0
+            - redis-cli -p 26379 sentinel get-master-addr-by-name ${REDIS_MASTER_NAME}
           initialDelaySeconds: 10
           periodSeconds: 5
       volumes:

--- a/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
@@ -40,19 +40,8 @@ spec:
 
           echo "Starting Redis Sentinel..."
           exec redis-sentinel /data/sentinel.conf
-        {{- if .Values.redis.auth.enabled }}
         env:
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              {{- if .Values.redis.auth.existingSecret }}
-              name: {{ .Values.redis.auth.existingSecret }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-              {{- else }}
-              name: {{ .Release.Name }}-redis-secret
-              key: password
-              {{- end }}
-        {{- end }}
+          {{- include "splunk-connect-for-snmp.redis-env" . | nindent 10 }}
         volumeMounts:
         - name: sentinel-config
           mountPath: /etc/redis

--- a/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
@@ -1,0 +1,84 @@
+{{- if eq .Values.redis.architecture "replication" }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-redis-sentinel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-redis-sentinel
+    app.kubernetes.io/component: sentinel
+spec:
+  serviceName: {{ .Release.Name }}-redis-sentinel
+  replicas: {{ .Values.redis.sentinel.replicas | default 3 }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-redis-sentinel
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-redis-sentinel
+      annotations:
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 }}
+    spec:
+      containers:
+      - name: sentinel
+        image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+        imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+        ports:
+        - containerPort: 26379
+          name: sentinel
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          cp /etc/redis/sentinel.conf /data/sentinel.conf
+          {{- if .Values.redis.auth.enabled }}
+          sed -i "s/\${REDIS_PASSWORD}/$REDIS_PASSWORD/g" /data/sentinel.conf
+          {{- end }}
+
+          echo "Starting Redis Sentinel..."
+          exec redis-sentinel /data/sentinel.conf
+        {{- if .Values.redis.auth.enabled }}
+        env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.redis.auth.existingSecret }}
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
+              {{- else }}
+              name: {{ .Release.Name }}-redis-secret
+              key: password
+              {{- end }}
+        {{- end }}
+        volumeMounts:
+        - name: sentinel-config
+          mountPath: /etc/redis
+        - name: sentinel-data
+          mountPath: /data
+        resources:
+          {{- toYaml .Values.redis.sentinel.resources | nindent 10 }}
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - redis-cli -p 26379 ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - redis-cli -p 26379 sentinel get-master-addr-by-name mymaster | grep snmp-redis-ha-0
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: sentinel-config
+        configMap:
+          name: {{ .Release.Name }}-redis-sentinel-config
+      - name: sentinel-data
+        emptyDir: {}
+{{- end }}

--- a/charts/splunk-connect-for-snmp/templates/redis/sentinel/sentinel-headless-service.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/sentinel/sentinel-headless-service.yaml
@@ -1,0 +1,19 @@
+{{- if eq .Values.redis.architecture "replication" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis-sentinel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-redis-sentinel
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless - required by StatefulSet
+  publishNotReadyAddresses: true  # Allow Sentinel discovery before ready
+  ports:
+  - port: 26379
+    targetPort: 26379
+    name: sentinel
+  selector:
+    app: {{ .Release.Name }}-redis-sentinel
+{{- end }}

--- a/charts/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -12,10 +12,11 @@ spec:
       {{- include "splunk-connect-for-snmp.scheduler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.scheduler.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
+        {{- with .Values.scheduler.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "splunk-connect-for-snmp.scheduler.selectorLabels" . | nindent 8 }}
     spec:
@@ -45,26 +46,7 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            {{- if .Values.redis.auth.enabled }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.redis.auth.existingSecret }}
-                  name: {{ .Values.redis.auth.existingSecret }}
-                  key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                  {{- else }}
-                  name: {{ .Release.Name }}-redis-secret
-                  key: password
-                  {{- end }}
-            {{- end }}
-            - name: REDIS_HOST
-              value: {{ .Release.Name }}-redis
-            - name: REDIS_PORT
-              value: "6379"
-            - name: REDIS_DB
-              value: "1"
-            - name: CELERY_DB
-              value: "0"
+            {{- include "splunk-connect-for-snmp.redis-env" . | nindent 12 }}
             - name: MONGO_URI
               value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
             - name: MIB_SOURCES

--- a/charts/splunk-connect-for-snmp/templates/sim/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/sim/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/common/sim-secret.yaml") . | sha256sum }}
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
       labels:
         {{- include "splunk-connect-for-snmp.sim.selectorLabels" . | nindent 8 }}
     spec:
@@ -44,6 +45,7 @@ spec:
           imagePullPolicy: {{ .Values.sim.pullPolicy | default "IfNotPresent" }}
           args: ["--config=/config/otel-collector-config.yaml"]
           env:
+            {{- include "splunk-connect-for-snmp.redis-env" . | nindent 12 }}
             - name: signalfxToken
               valueFrom:
                 secretKeyRef:

--- a/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -14,10 +14,11 @@ spec:
       {{- include "splunk-connect-for-snmp.traps.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.traps.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
+        {{- with .Values.traps.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "splunk-connect-for-snmp.traps.selectorLabels" . | nindent 8 }}
     spec:
@@ -49,26 +50,7 @@ spec:
               value: /app/config/config.yaml
             - name: MONGO_URI
               value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
-            - name: REDIS_HOST
-              value: {{ .Release.Name }}-redis
-            - name: REDIS_PORT
-              value: "6379"
-            - name: REDIS_DB
-              value: "1"
-            - name: CELERY_DB
-              value: "0"
-            {{- if .Values.redis.auth.enabled }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.redis.auth.existingSecret }}
-                  name: {{ .Values.redis.auth.existingSecret }}
-                  key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                  {{- else }}
-                  name: {{ .Release.Name }}-redis-secret
-                  key: password
-                  {{- end }}
-            {{- end }}
+            {{- include "splunk-connect-for-snmp.redis-env" . | nindent 12 }}
             - name: MIB_SOURCES
               value: "http://{{ printf "%s-%s" .Release.Name "mibserver" }}/asn1/@mib@"
             - name: MIB_INDEX

--- a/charts/splunk-connect-for-snmp/templates/ui/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/ui/_helpers.tpl
@@ -33,26 +33,7 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_HOST
-            value: {{ .Release.Name }}-redis
-          - name: REDIS_PORT
-            value: "6379"
-          - name: REDIS_DB
-            value: "1"
-          - name: CELERY_DB
-            value: "0"
-          {{- if .Values.redis.auth.enabled }}
-          - name: REDIS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                {{- if .Values.redis.auth.existingSecret }}
-                name: {{ .Values.redis.auth.existingSecret }}
-                key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                {{- else }}
-                name: {{ .Release.Name }}-redis-secret
-                key: password
-                {{- end }}
-          {{- end }}
+          {{ include "splunk-connect-for-snmp.redis-env" . | nindent 10 }}
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
           - name: MONGO_URI

--- a/charts/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: ui-backend-worker
+      annotations:
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 }}
     spec:
       containers:
       - name: ui-backend-worker
@@ -23,26 +25,7 @@ spec:
         env:
         - name: MONGO_URI
           value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
-        {{- if .Values.redis.auth.enabled }}
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              {{- if .Values.redis.auth.existingSecret }}
-              name: {{ .Values.redis.auth.existingSecret }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-              {{- else }}
-              name: {{ .Release.Name }}-redis-secret
-              key: password
-              {{- end }}
-        {{- end }}
-        - name: REDIS_HOST
-          value: {{ .Release.Name }}-redis
-        - name: REDIS_PORT
-          value: "6379"
-        - name: REDIS_DB
-          value: "1"
-        - name: CELERY_DB
-          value: "0"
+        {{ include "splunk-connect-for-snmp.redis-env" . | nindent 8 }}
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE

--- a/charts/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
@@ -29,7 +29,7 @@ spec:
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
-          value: sc4snmp
+          value: {{ .Release.Namespace | quote }}
         - name: VALUES_DIRECTORY
           {{- if .Values.UI.valuesFileDirectory }}
           value: {{ include "splunk-connect-for-snmp-ui.hostMountPath" . }}

--- a/charts/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: ui-backend
+      annotations:
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 }}
     spec:
       securityContext:
         runAsUser: 10000
@@ -45,26 +47,7 @@ spec:
         env:
         - name: MONGO_URI
           value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
-        {{- if .Values.redis.auth.enabled }}
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              {{- if .Values.redis.auth.existingSecret }}
-              name: {{ .Values.redis.auth.existingSecret }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-              {{- else }}
-              name: {{ .Release.Name }}-redis-secret
-              key: password
-              {{- end }}
-        {{- end }}
-        - name: REDIS_HOST
-          value: {{ .Release.Name }}-redis
-        - name: REDIS_PORT
-          value: "6379"
-        - name: REDIS_DB
-          value: "1"
-        - name: CELERY_DB
-          value: "0"
+        {{ include "splunk-connect-for-snmp.redis-env" . | nindent 8 }}
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE

--- a/charts/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
@@ -51,7 +51,7 @@ spec:
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
-          value: sc4snmp
+          value: {{ .Release.Namespace | quote }}
         - name: VALUES_DIRECTORY
           {{- if .Values.UI.valuesFileDirectory }}
           value: {{ include "splunk-connect-for-snmp-ui.hostMountPath" . }}

--- a/charts/splunk-connect-for-snmp/templates/ui/role-binding.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/role-binding.yaml
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: job-robot
-  namespace: sc4snmp
+  namespace: {{ .Release.Namespace | quote }}
 subjects:
 - kind: ServiceAccount
   name: job-robot # Name of the ServiceAccount
-  namespace: sc4snmp
+  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: Role # This must be Role or ClusterRole
   name: job-robot # This must match the name of the Role or ClusterRole you wish to bind to

--- a/charts/splunk-connect-for-snmp/templates/ui/role.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: sc4snmp
+  namespace: {{ .Release.Namespace | quote }}
   name: job-robot
 rules:
 - apiGroups: [""] # "" indicates the core API group

--- a/charts/splunk-connect-for-snmp/templates/ui/service-account.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/service-account.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: job-robot
-  namespace: sc4snmp
+  namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -91,16 +91,9 @@ Common labels
 {{- define "environmental-variables" -}}
 - name: CONFIG_PATH
   value: /app/config/config.yaml
-- name: REDIS_HOST
-  value: {{ .Release.Name }}-redis
-- name: REDIS_PORT
-  value: "6379"
-- name: REDIS_DB
-  value: "1"
-- name: CELERY_DB
-  value: "0"
 - name: SC4SNMP_VERSION
   value: {{ .Chart.Version | default "0.0.0" }}
+{{- include "splunk-connect-for-snmp.redis-env" . | nindent 0 }}
 - name: MONGO_URI
   value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
 - name: WALK_RETRY_MAX_INTERVAL

--- a/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
+++ b/charts/splunk-connect-for-snmp/templates/worker/_helpers.tpl
@@ -93,7 +93,7 @@ Common labels
   value: /app/config/config.yaml
 - name: SC4SNMP_VERSION
   value: {{ .Chart.Version | default "0.0.0" }}
-{{- include "splunk-connect-for-snmp.redis-env" . | nindent 0 }}
+{{ include "splunk-connect-for-snmp.redis-env" . }}
 - name: MONGO_URI
   value: {{ include "splunk-connect-for-snmp.mongo_uri" . }}
 - name: WALK_RETRY_MAX_INTERVAL

--- a/charts/splunk-connect-for-snmp/templates/worker/flower/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/flower/deployment.yaml
@@ -41,18 +41,7 @@ spec:
             ]
           env:
             {{- include "environmental-variables" . | nindent 12 }}
-            {{- if .Values.redis.auth.enabled }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.redis.auth.existingSecret }}
-                  name: {{ .Values.redis.auth.existingSecret }}
-                  key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                  {{- else }}
-                  name: {{ .Release.Name }}-redis-secret
-                  key: password
-                  {{- end }}
-            {{- end }}
+            {{ include "splunk-connect-for-snmp.redis-env" . | nindent 12 }}
           ports:
             - containerPort: 5555
           

--- a/charts/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -14,10 +14,11 @@ spec:
       {{- include "splunk-connect-for-snmp.worker.poller.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.worker.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
+        {{- with .Values.worker.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "splunk-connect-for-snmp.worker.poller.selectorLabels" . | nindent 8 }}
     spec:
@@ -47,18 +48,6 @@ spec:
           env:
             {{- include "environmental-variables" . | nindent 12 }}
             {{- include "environmental-variables-poller" . | nindent 12 }}
-            {{- if .Values.redis.auth.enabled }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.redis.auth.existingSecret }}
-                  name: {{ .Values.redis.auth.existingSecret }}
-                  key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                  {{- else }}
-                  name: {{ .Release.Name }}-redis-secret
-                  key: password
-                  {{- end }}
-            {{- end }}
           {{- if .Values.worker.livenessProbe.enabled }}
           livenessProbe:
             exec:

--- a/charts/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "splunk-connect-for-snmp.worker.sender.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.worker.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
+        {{- with .Values.worker.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "splunk-connect-for-snmp.worker.sender.selectorLabels" . | nindent 8 }}
     spec:
@@ -53,18 +54,6 @@ spec:
               value: /app/hec-mtls/tls.key
             - name: SPLUNK_HEC_MTLS_CA_CERT
               value: /app/hec-mtls/cacert.pem
-            {{- end }}
-            {{- if .Values.redis.auth.enabled }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.redis.auth.existingSecret }}
-                  name: {{ .Values.redis.auth.existingSecret }}
-                  key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                  {{- else }}
-                  name: {{ .Release.Name }}-redis-secret
-                  key: password
-                  {{- end }}
             {{- end }}
           {{- if .Values.worker.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -14,10 +14,11 @@ spec:
       {{- include "splunk-connect-for-snmp.worker.trap.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.worker.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 -}}
+        {{- with .Values.worker.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "splunk-connect-for-snmp.worker.trap.selectorLabels" . | nindent 8 }}
     spec:
@@ -47,18 +48,6 @@ spec:
           env:
             {{- include "environmental-variables" . | nindent 12 }}
             {{- include "environmental-variables-trap" . | nindent 12 }}
-            {{- if .Values.redis.auth.enabled }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.redis.auth.existingSecret }}
-                  name: {{ .Values.redis.auth.existingSecret }}
-                  key: {{ .Values.redis.auth.existingSecretPasswordKey | default "password" }}
-                  {{- else }}
-                  name: {{ .Release.Name }}-redis-secret
-                  key: password
-                  {{- end }}
-            {{- end }}
           volumeMounts:
             - name: config
               mountPath: "/app/config"

--- a/charts/splunk-connect-for-snmp/values.schema.json
+++ b/charts/splunk-connect-for-snmp/values.schema.json
@@ -728,6 +728,9 @@
         "nodeSelector": {
           "type": "object"
         },
+        "podAnnotations": {
+          "type": "object"
+        },
         "tolerations": {
           "type": "array"
         }

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -23,12 +23,12 @@ UI:
   frontEnd:
     NodePort: 30001
     repository: ghcr.io/splunk/sc4snmp-ui/frontend/container
-    tag: "1.1.1"
+    tag: "1.1.1-beta.2"
     pullPolicy: "Always"
   backEnd:
     NodePort: 30002
     repository: ghcr.io/splunk/sc4snmp-ui/backend/container
-    tag: "1.1.1"
+    tag: "1.1.1-beta.2"
     pullPolicy: "Always"
   # Base container that sets permissions for folders mounted to UI containers
   init:
@@ -432,6 +432,7 @@ inventory:
 
   nodeSelector: {}
   tolerations: []
+  podAnnotations: {}
 
 traps:
   # this is a simple server that can handle SNMP traps sent by SNMP devices like routers or switches.
@@ -596,9 +597,21 @@ mongodb:
       repository: bitnamilegacy/os-shell
     enabled: true
 redis:
-  # Mode selector: "standalone"
-  # TODO: add "replication"
+  # Mode selector: "standalone", "replication"
   architecture: standalone
+
+  # Options for Redis replication
+  replicas: 3
+  sentinel:
+    replicas: 3
+    quorum: 2
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
 
   # Authentication
   auth:
@@ -637,5 +650,10 @@ redis:
   podSecurityContext:
     runAsUser: 999
     fsGroup: 999
+
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+      enabled: true
 
 commonAnnotations: {}

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -627,13 +627,17 @@ redis:
     pullPolicy: IfNotPresent
 
   # Resources
-  resources:
-    requests:
-      cpu: 250m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
+  resources: {}
+  #  **Quick sizing:**
+  #  - Cache only: Set `redis.resources.limits.memory` to 1.5× expected data size
+  #  - With persistence: Set to 2.5-3× expected data size
+  #  resources:
+  #    requests:
+  #      cpu: 500m
+  #      memory: 1Gi
+  #    limits:
+  #      cpu: 1000m
+  #      memory: 2Gi
 
   # Storage
   storage:

--- a/construct-redis-url.sh
+++ b/construct-redis-url.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+# Constructs REDIS_URL and CELERY_BROKER_URL from components if not already set
+
+# Detect mode
+REDIS_MODE="${REDIS_MODE:-standalone}"
+
+# Only construct if URLs not already set
+if [ -z "$REDIS_URL" ] || [ -z "$CELERY_BROKER_URL" ]; then
+
+  if [ "$REDIS_MODE" = "replication" ]; then
+    # Sentinel HA mode
+    echo "Redis mode: Sentinel HA"
+
+    REDIS_SENTINEL_SERVICE="${REDIS_SENTINEL_SERVICE:-snmp-redis-sentinel}"
+    REDIS_HEADLESS_SERVICE="${REDIS_HEADLESS_SERVICE:-snmp-redis-headless}"
+    REDIS_SENTINEL_PORT="${REDIS_SENTINEL_PORT:-26379}"
+    REDIS_PORT="${REDIS_PORT:-6379}"
+    REDIS_MASTER_NAME="${REDIS_MASTER_NAME:-mymaster}"
+    REDIS_DB="${REDIS_DB:-1}"
+    CELERY_DB="${CELERY_DB:-0}"
+
+    if [ -n "$REDIS_PASSWORD" ]; then
+      SENTINEL_SCHEME="sentinel://:${REDIS_PASSWORD}@${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
+      REDBEAT_SCHEME="redis-sentinel://:${REDIS_PASSWORD}@${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
+      REDIS_HA_CHECK="redis://:${REDIS_PASSWORD}@${REDIS_HEADLESS_SERVICE}:${REDIS_PORT}"
+    else
+      SENTINEL_SCHEME="sentinel://${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
+      REDBEAT_SCHEME="redis-sentinel://${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
+      REDIS_HA_CHECK="redis://${REDIS_HEADLESS_SERVICE}:${REDIS_PORT}"
+
+    fi
+
+    # Celery broker uses sentinel://
+    : "${CELERY_BROKER_URL:=${SENTINEL_SCHEME}/${CELERY_DB}#master_name=${REDIS_MASTER_NAME}}"
+
+    # RedBeat uses redis-sentinel:// with master_name query
+    : "${REDIS_URL:=${REDBEAT_SCHEME}/${REDIS_DB}#master_name=${REDIS_MASTER_NAME}}"
+    SENTINEL_CHECK="redis://${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
+    # For healthcheck / wait-for-dep - space-separated list
+    REDIS_DEPENDENCIES="${SENTINEL_CHECK} ${REDIS_HA_CHECK}"
+
+  else
+    # Standalone mode
+    echo "Redis mode: Standalone"
+    REDIS_HOST="${REDIS_HOST:-snmp-redis}"
+    REDIS_PORT="${REDIS_PORT:-6379}"
+
+    if [ -n "$REDIS_PASSWORD" ]; then
+      BASE="redis://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT"
+    else
+      BASE="redis://$REDIS_HOST:$REDIS_PORT"
+    fi
+
+    : "${REDIS_URL:=$BASE/${REDIS_DB:-1}}"
+    : "${CELERY_BROKER_URL:=$BASE/${CELERY_DB:-0}}"
+
+    # For healthcheck / wait-for-dep - space-separated list
+    REDIS_DEPENDENCIES="${REDIS_URL} ${CELERY_BROKER_URL}"
+  fi
+
+  export REDIS_URL
+  export CELERY_BROKER_URL
+  export REDIS_DEPENDENCIES
+  export REDIS_MODE
+fi

--- a/construct-redis-url.sh
+++ b/construct-redis-url.sh
@@ -21,14 +21,13 @@ if [ -z "$REDIS_URL" ] || [ -z "$CELERY_BROKER_URL" ]; then
 
     if [ -n "$REDIS_PASSWORD" ]; then
       SENTINEL_SCHEME="sentinel://:${REDIS_PASSWORD}@${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
-      REDBEAT_SCHEME="redis-sentinel://:${REDIS_PASSWORD}@${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
       REDIS_HA_CHECK="redis://:${REDIS_PASSWORD}@${REDIS_HEADLESS_SERVICE}:${REDIS_PORT}"
     else
       SENTINEL_SCHEME="sentinel://${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
-      REDBEAT_SCHEME="redis-sentinel://${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
       REDIS_HA_CHECK="redis://${REDIS_HEADLESS_SERVICE}:${REDIS_PORT}"
-
     fi
+
+    REDBEAT_SCHEME="redis-sentinel://${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
 
     # Celery broker uses sentinel://
     : "${CELERY_BROKER_URL:=${SENTINEL_SCHEME}/${CELERY_DB}#master_name=${REDIS_MASTER_NAME}}"
@@ -36,8 +35,12 @@ if [ -z "$REDIS_URL" ] || [ -z "$CELERY_BROKER_URL" ]; then
     # RedBeat uses redis-sentinel:// with master_name query
     : "${REDIS_URL:=${REDBEAT_SCHEME}/${REDIS_DB}#master_name=${REDIS_MASTER_NAME}}"
     SENTINEL_CHECK="redis://${REDIS_SENTINEL_SERVICE}:${REDIS_SENTINEL_PORT}"
+
+    # Checking specific databases
+    REDIS_HA_DB_0="${REDIS_HA_CHECK}/${REDIS_DB}"
+    REDIS_HA_DB_1="${REDIS_HA_CHECK}/${CELERY_DB}"
     # For healthcheck / wait-for-dep - space-separated list
-    REDIS_DEPENDENCIES="${SENTINEL_CHECK} ${REDIS_HA_CHECK}"
+    REDIS_DEPENDENCIES="${SENTINEL_CHECK} ${REDIS_HA_CHECK} ${REDIS_HA_DB_0} ${REDIS_HA_DB_1}"
 
   else
     # Standalone mode

--- a/docs/microk8s/configuration/redis-configuration.md
+++ b/docs/microk8s/configuration/redis-configuration.md
@@ -29,13 +29,17 @@ redis:
     pullPolicy: IfNotPresent
 
   # Resources
-  resources:
-    requests:
-      cpu: 250m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
+  resources: {}
+  #  **Quick sizing:**
+  #  - Cache only: Set `redis.resources.limits.memory` to 1.5× expected data size
+  #  - With persistence: Set to 2.5-3× expected data size
+  #  resources:
+  #    requests:
+  #      cpu: 500m
+  #      memory: 1Gi
+  #    limits:
+  #      cpu: 1000m
+  #      memory: 2Gi
 
   # Storage
   storage:
@@ -72,10 +76,10 @@ redis:
 | redis.image.repository                   | string | `redis`             | Container image repository.                                                             |
 | redis.image.tag                          | string | `8.2.2`             | Image tag / Redis version.                                                              |
 | redis.image.pullPolicy                   | string | `IfNotPresent`      | Image pull policy.                                                                      |
-| redis.resources.requests.cpu             | string | `250m`              | Guaranteed minimum CPU.                                                                 |
-| redis.resources.requests.memory          | string | `256Mi`             | Guaranteed minimum memory.                                                              |
-| redis.resources.limits.cpu               | string | `500m`              | CPU limit.                                                                              |
-| redis.resources.limits.memory            | string | `512Mi`             | Memory limit.                                                                           |
+| redis.resources.requests.cpu             | string | `""`                | Guaranteed minimum CPU.                                                                 |
+| redis.resources.requests.memory          | string | `""`                | Guaranteed minimum memory.                                                              |
+| redis.resources.limits.cpu               | string | `""`                | CPU limit.                                                                              |
+| redis.resources.limits.memory            | string | `""`                | Memory limit.                                                                           |
 | redis.storage.enabled                    | bool   | `true`              | Create PersistentVolumeClaim.                                                           |
 | redis.storage.storageClassName           | string | `microk8s-hostpath` | StorageClass for the PVC.                                                               |
 | redis.storage.accessModes                | list   | `[ReadWriteOnce]`   | PVC access modes.                                                                       |
@@ -182,6 +186,28 @@ For MicrokK8s on Ubuntu, you can enable NFS this way:
     ```
 
 The solution might differ depending on the platform and Kubernetes distribution.
+
+### Resource Requirements
+
+Redis memory limits depend on your data size and persistence strategy.
+
+**Quick sizing:**
+
+- Cache only: Set `redis.resources.limits.memory` to 1.5× expected data size
+- With persistence: Set to 2.5-3× expected data size
+
+**Examples:**
+```yaml
+redis:
+  limits:
+    memory: "4Gi"
+    cpu: "1000m"
+  requests:
+    memory: "1Gi"
+    cpu: "500m"
+```
+
+By default no resource limits our set. You can define them in the `values.yaml` file as shown above.
 
 ### Use authentication for Redis
 

--- a/docs/microk8s/configuration/redis-configuration.md
+++ b/docs/microk8s/configuration/redis-configuration.md
@@ -12,7 +12,7 @@ Redis configuration is maintained in the `redis` section of `values.yaml`, which
 
 ```yaml
 redis:
-  # Mode selector: "standalone"
+  # Mode selector: "standalone", "replication"
   architecture: standalone
 
   # Authentication
@@ -55,29 +55,95 @@ redis:
     fsGroup: 999
 ```
 
-| Key                                  | Type   | Default             | Description                                                                             |
-|--------------------------------------|--------|---------------------|-----------------------------------------------------------------------------------------|
-| redis.architecture                   | string | `standalone`        | Deployment mode (currently only standalone supported).                                  |
-| redis.auth.enabled                   | bool   | `false`             | Enable Redis AUTH.                                                                      |
-| redis.auth.password                  | string | `""`                | Password when AUTH enabled (avoid committing; prefer secret).                           |
-| redis.auth.existingSecret            | string | `""`                | Name of existing Kubernetes Secret providing the password.                              |
-| redis.auth.existingSecretPasswordKey | string | `password`          | Key inside the existing secret containing the password.                                 |
-| redis.image.repository               | string | `redis`             | Container image repository.                                                             |
-| redis.image.tag                      | string | `8.2.2`             | Image tag / Redis version.                                                              |
-| redis.image.pullPolicy               | string | `IfNotPresent`      | Image pull policy.                                                                      |
-| redis.resources.requests.cpu         | string | `250m`              | Guaranteed minimum CPU.                                                                 |
-| redis.resources.requests.memory      | string | `256Mi`             | Guaranteed minimum memory.                                                              |
-| redis.resources.limits.cpu           | string | `500m`              | CPU limit.                                                                              |
-| redis.resources.limits.memory        | string | `512Mi`             | Memory limit.                                                                           |
-| redis.storage.enabled                | bool   | `true`              | Create PersistentVolumeClaim.                                                           |
-| redis.storage.storageClassName       | string | `microk8s-hostpath` | StorageClass for the PVC.                                                               |
-| redis.storage.accessModes            | list   | `[ReadWriteOnce]`   | PVC access modes.                                                                       |
-| redis.storage.size                   | string | `5Gi`               | Requested persistent volume size.                                                       |
-| redis.persistence.aof.enabled        | bool   | `true`              | Enable Append Only File persistence.                                                    |
-| redis.persistence.aof.fsync          | string | `everysec`          | AOF fsync policy (`always`, `everysec`, `no`). Necessary to migrate from bitnami Redis. |
-| redis.podSecurityContext.runAsUser   | int    | `999`               | UID for the container (non-root hardening).                                             |
-| redis.podSecurityContext.fsGroup     | int    | `999`               | FS group owning mounted volumes.                                                        |
+| Key                                      | Type   | Default             | Description                                                                             |
+|------------------------------------------|--------|---------------------|-----------------------------------------------------------------------------------------|
+| redis.architecture                       | string | `standalone`        | Deployment mode (standalone or replication).                                            |
+| redis.replicas                           | int    | `3`                 | Data pod count (used only in replication mode).                                         |
+| redis.sentinel.replicas                  | int    | `3`                 | Sentinel pod count (odd recommended).                                                   |
+| redis.sentinel.quorum                    | int    | `2`                 | Required Sentinel votes for failover.                                                   |
+| redis.sentinel.resources.requests.cpu    | string | `50m`               | Guaranteed Sentinel minimum CPU.                                                        |
+| redis.sentinel.resources.requests.memory | string | `64Mi`              | Guaranteed Sentinel minimum memory.                                                     |
+| redis.sentinel.resources.limits.cpu      | string | `100m`              | Guaranteed Sentinel minimum CPU.                                                        |
+| redis.sentinel.resources.limits.memory   | string | `128Mi`             | Guaranteed Sentinel minimum memory.                                                     |
+| redis.auth.enabled                       | bool   | `false`             | Enable Redis AUTH.                                                                      |
+| redis.auth.password                      | string | `""`                | Password when AUTH enabled (avoid committing; prefer secret).                           |
+| redis.auth.existingSecret                | string | `""`                | Name of existing Kubernetes Secret providing the password.                              |
+| redis.auth.existingSecretPasswordKey     | string | `password`          | Key inside the existing secret containing the password.                                 |
+| redis.image.repository                   | string | `redis`             | Container image repository.                                                             |
+| redis.image.tag                          | string | `8.2.2`             | Image tag / Redis version.                                                              |
+| redis.image.pullPolicy                   | string | `IfNotPresent`      | Image pull policy.                                                                      |
+| redis.resources.requests.cpu             | string | `250m`              | Guaranteed minimum CPU.                                                                 |
+| redis.resources.requests.memory          | string | `256Mi`             | Guaranteed minimum memory.                                                              |
+| redis.resources.limits.cpu               | string | `500m`              | CPU limit.                                                                              |
+| redis.resources.limits.memory            | string | `512Mi`             | Memory limit.                                                                           |
+| redis.storage.enabled                    | bool   | `true`              | Create PersistentVolumeClaim.                                                           |
+| redis.storage.storageClassName           | string | `microk8s-hostpath` | StorageClass for the PVC.                                                               |
+| redis.storage.accessModes                | list   | `[ReadWriteOnce]`   | PVC access modes.                                                                       |
+| redis.storage.size                       | string | `5Gi`               | Requested persistent volume size.                                                       |
+| redis.persistence.aof.enabled            | bool   | `true`              | Enable Append Only File persistence.                                                    |
+| redis.persistence.aof.fsync              | string | `everysec`          | AOF fsync policy (`always`, `everysec`, `no`). Necessary to migrate from bitnami Redis. |
+| redis.podSecurityContext.runAsUser       | int    | `999`               | UID for the container (non-root hardening).                                             |
+| redis.podSecurityContext.fsGroup         | int    | `999`               | FS group owning mounted volumes.                                                        |
 
+
+### Architecture modes
+
+#### Standalone mode (default)
+
+**Architecture**:
+
+* Single Redis pod
+* Simple deployment
+* Minimal resource overhead
+
+Use cases:
+
+* Single-node environments
+* Non-critical workloads
+
+Characteristics:
+
+* Resources: 1 Redis pod
+* Complexity: Low
+* Recovery time: ~30-60 seconds (Kubernetes reschedules pod on node failure)
+
+##### Configuration
+
+```yaml
+redis:
+  architecture: standalone
+```
+
+#### Replication mode
+
+Architecture:
+
+* 3 Redis pods (1 master + 2 replicas)
+* 3 Redis Sentinel pods (monitoring and automatic failover)
+* Automatic master promotion on failure
+
+Use cases:
+
+* Production deployments
+* Multi-node Kubernetes clusters
+* Critical workloads requiring high availability
+
+Characteristics:
+
+* Recovery time: ~5-10 seconds (Sentinel automatic failover)
+* Resources: 6 pods total (3 Redis + 3 Sentinel)
+* Complexity: Medium
+
+##### Configuration
+
+```yaml
+redis:
+  architecture: replication
+  replicas: 3
+  sentinel:
+    replicas: 3
+    quorum: 2
+```
 
 ### Use authentication for Redis
 
@@ -117,8 +183,6 @@ redis:
 ```
 !!!warning
     For smoother migration, it's better to create a new secret with the updated values and then update your configuration to reference this new secret, rather than modifying an existing secret in place.
-    
-    When changing the content of a Kubernetes Secret that is already in use, the running pods will not automatically pick up the new values. You must recreate the pods for them to use the updated secret.
 
 ### Migration from Bitnami Redis
 
@@ -131,3 +195,5 @@ The chart automatically detects and migrates data from existing Bitnami Redis de
 
 No manual intervention required — simply upgrade your deployment with the new chart.
 
+!!!note
+   Migration between Bitnami Redis and the new chart is 

--- a/docs/microk8s/configuration/redis-configuration.md
+++ b/docs/microk8s/configuration/redis-configuration.md
@@ -168,7 +168,7 @@ redis:
 !!!note
     The `storageClassName` must point to a `StorageClass` that supports network-attached volumes with `ReadWriteMany` (or `ReadWriteOnce` with cross-node support). Examples: NFS, Ceph, EBS, GCP Persistent Disk, Azure Disk.
 
-For MicrokK8s on Ubuntu, you can enable NFS this way:
+EXAMPLE: For MicroK8s on Ubuntu, you can enable NFS this way:
 
 1. Enable NFS client on ALL nodes:
     ```bash

--- a/docs/microk8s/sc4snmp-installation.md
+++ b/docs/microk8s/sc4snmp-installation.md
@@ -223,7 +223,7 @@ snmp-splunk-connect-for-snmp-trap-684d57dc8d-722tv            1/1     Terminatin
 snmp-splunk-connect-for-snmp-trap-684d57dc8d-z68lb            1/1     Terminating   1 (5h21m ago)   22h
 ```
 
-## Restart Splunk Connect for SNMP
+## Reinstall Splunk Connect for SNMP
 First run the command to uninstall SC4SNMP, wait until all pods are removed, then use the command to install sc4snmp again.
 
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,30 +1,11 @@
 #!/usr/bin/env sh
 set -e
 . /app/.venv/bin/activate
+. /app/construct-redis-url.sh
 LOG_LEVEL=${LOG_LEVEL:=INFO}
 WORKER_CONCURRENCY=${WORKER_CONCURRENCY:=4}
 
-# Only construct if URLs not already set
-if [ -z "$REDIS_URL" ] || [ -z "$CELERY_BROKER_URL" ]; then
-  # Defaults
-  REDIS_HOST="${REDIS_HOST:-snmp-redis}"
-  REDIS_PORT="${REDIS_PORT:-6379}"
-
-  # Build base
-  if [ -n "$REDIS_PASSWORD" ]; then
-    BASE="redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}"
-  else
-    BASE="redis://${REDIS_HOST}:${REDIS_PORT}"
-  fi
-
-  # Set if not already set
-  : "${REDIS_URL:=$BASE/${REDIS_DB:-1}}"
-  : "${CELERY_BROKER_URL:=$BASE/${CELERY_DB:-0}}"
-
-  export REDIS_URL CELERY_BROKER_URL
-fi
-
-wait-for-dep "${CELERY_BROKER_URL}" "${REDIS_URL}" "${MONGO_URI}" "${MIB_INDEX}"
+wait-for-dep ${REDIS_DEPENDENCIES} "${MONGO_URI}" "${MIB_INDEX}"
 
 case $1 in
 

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -14,7 +14,8 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-inventory
         app.kubernetes.io/instance: release-name
@@ -28,12 +29,18 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_URL
-            value: redis://release-name-redis-master:6379/1
+          - name: REDIS_MODE
+            value: "standalone"
+          - name: REDIS_HOST
+            value: release-name-redis
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
-          - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,16 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -14,7 +14,8 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-inventory
         app.kubernetes.io/instance: release-name
@@ -28,12 +29,18 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_URL
-            value: redis://release-name-redis-master:6379/1
+          - name: REDIS_MODE
+            value: "standalone"
+          - name: REDIS_HOST
+            value: release-name-redis
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
-          - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,16 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -43,10 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
         app.kubernetes.io/instance: release-name
@@ -43,12 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -43,12 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -43,12 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -14,7 +14,8 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-inventory
         app.kubernetes.io/instance: release-name
@@ -28,12 +29,18 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_URL
-            value: redis://release-name-redis-master:6379/1
+          - name: REDIS_MODE
+            value: "standalone"
+          - name: REDIS_HOST
+            value: release-name-redis
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
-          - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,16 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -43,10 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
         app.kubernetes.io/instance: release-name
@@ -43,12 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -43,12 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -43,12 +45,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -14,7 +14,8 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-inventory
         app.kubernetes.io/instance: release-name
@@ -28,12 +29,18 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_URL
-            value: redis://release-name-redis-master:6379/1
+          - name: REDIS_MODE
+            value: "standalone"
+          - name: REDIS_HOST
+            value: release-name-redis
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
-          - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,16 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/configmap-backend.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/configmap-backend.yaml
@@ -35,12 +35,19 @@ data:
               env:
               - name: CONFIG_PATH
                 value: /app/config/config.yaml
-              - name: REDIS_URL
-                value: redis://release-name-redis-master:6379/1
+              
+              - name: REDIS_MODE
+                value: "standalone"
+              - name: REDIS_HOST
+                value: release-name-redis
+              - name: REDIS_PORT
+                value: "6379"
+              - name: REDIS_DB
+                value: "1"
+              - name: CELERY_DB
+                value: "0"
               - name: INVENTORY_PATH
                 value: /app/inventory/inventory.csv
-              - name: CELERY_BROKER_URL
-                value: redis://release-name-redis-master:6379/0
               - name: MONGO_URI
                 value: mongodb://release-name-mongodb:27017
               - name: MIB_SOURCES

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         app: ui-backend-worker
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
     spec:
       containers:
       - name: ui-backend-worker
@@ -24,14 +26,21 @@ spec:
         env:
         - name: MONGO_URI
           value: mongodb://release-name-mongodb:27017
-        - name: REDIS_URL
-          value: redis://release-name-redis-master:6379/3
+        
+        - name: REDIS_MODE
+          value: "standalone"
+        - name: REDIS_HOST
+          value: release-name-redis
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "1"
+        - name: CELERY_DB
+          value: "0"
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
           value: sc4snmp
-        - name: CELERY_BROKER_URL
-          value: redis://release-name-redis-master:6379/2
         - name: VALUES_DIRECTORY
           value: /var/values_dir
         ports:

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
@@ -40,7 +40,7 @@ spec:
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
-          value: sc4snmp
+          value: "default"
         - name: VALUES_DIRECTORY
           value: /var/values_dir
         ports:

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         app: ui-backend
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
     spec:
       securityContext:
         runAsUser: 10000
@@ -44,14 +46,21 @@ spec:
         env:
         - name: MONGO_URI
           value: mongodb://release-name-mongodb:27017
-        - name: REDIS_URL
-          value: redis://release-name-redis-master:6379/3
+        
+        - name: REDIS_MODE
+          value: "standalone"
+        - name: REDIS_HOST
+          value: release-name-redis
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "1"
+        - name: CELERY_DB
+          value: "0"
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
           value: sc4snmp
-        - name: CELERY_BROKER_URL
-          value: redis://release-name-redis-master:6379/2
         - name: VALUES_DIRECTORY
           value: /var/values_dir
         - name: VALUES_FILE

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
@@ -60,7 +60,7 @@ spec:
         - name: JOB_CONFIG_PATH
           value: /config/job_config.yaml
         - name: JOB_NAMESPACE
-          value: sc4snmp
+          value: "default"
         - name: VALUES_DIRECTORY
           value: /var/values_dir
         - name: VALUES_FILE

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/role-binding.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/role-binding.yaml
@@ -4,11 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: job-robot
-  namespace: sc4snmp
+  namespace: "default"
 subjects:
 - kind: ServiceAccount
   name: job-robot # Name of the ServiceAccount
-  namespace: sc4snmp
+  namespace: "default"
 roleRef:
   kind: Role # This must be Role or ClusterRole
   name: job-robot # This must match the name of the Role or ClusterRole you wish to bind to

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/role.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: sc4snmp
+  namespace: "default"
   name: job-robot
 rules:
 - apiGroups: [""] # "" indicates the core API group

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/service-account.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/service-account.yaml
@@ -4,4 +4,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: job-robot
-  namespace: sc4snmp
+  namespace: "default"

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -14,7 +14,8 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-inventory
         app.kubernetes.io/instance: release-name
@@ -28,12 +29,18 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_URL
-            value: redis://release-name-redis-master:6379/1
+          - name: REDIS_MODE
+            value: "standalone"
+          - name: REDIS_HOST
+            value: release-name-redis
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
-          - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,16 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -14,7 +14,8 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-inventory
         app.kubernetes.io/instance: release-name
@@ -28,12 +29,18 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_URL
-            value: redis://release-name-redis-master:6379/1
+          - name: REDIS_MODE
+            value: "standalone"
+          - name: REDIS_HOST
+            value: release-name-redis
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
-          - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,16 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -14,7 +14,8 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
-
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-inventory
         app.kubernetes.io/instance: release-name
@@ -28,12 +29,18 @@ spec:
           env:
           - name: CONFIG_PATH
             value: /app/config/config.yaml
-          - name: REDIS_URL
-            value: redis://release-name-redis-master:6379/1
+          - name: REDIS_MODE
+            value: "standalone"
+          - name: REDIS_HOST
+            value: release-name-redis
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
           - name: INVENTORY_PATH
             value: /app/inventory/inventory.csv
-          - name: CELERY_BROKER_URL
-            value: redis://release-name-redis-master:6379/0
           - name: MONGO_URI
             value: mongodb://release-name-mongodb:27017
           - name: MIB_SOURCES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,16 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: MIB_SOURCES

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/scheduler-config.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/scheduler-config.yaml
@@ -1,0 +1,42 @@
+---
+# Source: splunk-connect-for-snmp/templates/common/scheduler-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: splunk-connect-for-snmp-config
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |-
+      profiles:
+        IF_profile:
+          frequency: 600
+          varBinds:
+            - [ "IF-MIB", "ifDescr" ]
+            - [ "IF-MIB", "ifAdminStatus" ]
+            - [ "IF-MIB", "ifName" ]
+            - [ 'IF-MIB','ifAlias' ]
+            - [ "IF-MIB", "ifInDiscards" ]
+            - [ "IF-MIB", "ifInErrors" ]
+            - [ "IF-MIB", "ifInNUcastPkts" ]
+            - [ "IF-MIB", "ifInOctets" ]
+            - [ "IF-MIB", "ifInUcastPkts" ]
+            - [ "IF-MIB", "ifInUnknownProtos" ]
+            - [ "IF-MIB", "ifOutDiscards" ]
+            - [ "IF-MIB", "ifOutErrors" ]
+            - [ "IF-MIB", "ifOutNUcastPkts" ]
+            - [ "IF-MIB", "ifOutOctets" ]
+            - [ "IF-MIB", "ifOutQLen" ]
+            - [ "IF-MIB", "ifOutUcastPkts" ]
+        
+      communities:
+        public:
+          communityIndex:
+          contextEngineId:
+          contextName:
+          tag:
+          securityName:

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
@@ -1,0 +1,16 @@
+---
+# Source: splunk-connect-for-snmp/templates/common/scheduler-inventory.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: splunk-connect-for-snmp-inventory
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+data:
+  inventory.csv: |
+    address,port,version,community,secret,security_engine,walk_interval,profiles,smart_profiles,delete
+    54.82.41.24,,2c,public,,,1800,IF_profile,false,

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/splunk-secret.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/splunk-secret.yaml
@@ -1,0 +1,9 @@
+---
+# Source: splunk-connect-for-snmp/templates/common/splunk-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-connect-for-snmp-splunk
+type: Opaque
+data:
+  hec_token: "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/traps-config.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/common/traps-config.yaml
@@ -1,0 +1,18 @@
+---
+# Source: splunk-connect-for-snmp/templates/common/traps-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: splunk-connect-for-snmp-traps
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |-
+      communities:
+        2c:
+        - public
+        - homelab

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -1,0 +1,111 @@
+---
+# Source: splunk-connect-for-snmp/templates/inventory/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-splunk-connect-for-snmp-inventory
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-inventory
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-inventory
+        app.kubernetes.io/instance: release-name
+    spec:
+      containers:
+        - name: splunk-connect-for-snmp-inventory
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
+          imagePullPolicy: Always
+          args:
+              ["inventory"]
+          env:
+          - name: CONFIG_PATH
+            value: /app/config/config.yaml
+          - name: REDIS_MODE
+            value: "replication"
+          - name: REDIS_SENTINEL_SERVICE
+            value: release-name-redis-sentinel
+          - name: REDIS_HEADLESS_SERVICE
+            value: release-name-redis-headless
+          - name: NAMESPACE
+            value: default
+          - name: REDIS_SENTINEL_REPLICAS
+            value: "3"
+          - name: REDIS_SENTINEL_PORT
+            value: "26379"
+          - name: REDIS_MASTER_NAME
+            value: mymaster
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: release-name-redis-secret
+                key: password
+          - name: INVENTORY_PATH
+            value: /app/inventory/inventory.csv
+          - name: MONGO_URI
+            value: mongodb://release-name-mongodb:27017
+          - name: MIB_SOURCES
+            value: "http://release-name-mibserver/asn1/@mib@"
+          - name: MIB_INDEX
+            value: "http://release-name-mibserver/index.csv"
+          - name: MIB_STANDARD
+            value: "http://release-name-mibserver/standard.txt"
+          - name: LOG_LEVEL
+            value: INFO
+          - name: CHAIN_OF_TASKS_EXPIRY_TIME
+            value: "60"
+          - name: CONFIG_FROM_MONGO
+            value: "false"
+          - name: ENABLE_FULL_WALK
+            value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: "/app/config"
+              readOnly: true
+            - name: inventory
+              mountPath: "/app/inventory"
+              readOnly: true
+            - name: pysnmp-cache-volume
+              mountPath: "/.pysnmp/"
+              readOnly: false
+            - name: tmp
+              mountPath: "/tmp/"
+              readOnly: false
+
+      volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: config
+          configMap:
+            # Provide the name of the ConfigMap you want to mount.
+            name: splunk-connect-for-snmp-config
+            # An array of keys from the ConfigMap to create as files
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: inventory
+          configMap:
+            # Provide the name of the ConfigMap you want to mount.
+            name: splunk-connect-for-snmp-inventory
+            # An array of keys from the ConfigMap to create as files
+            items:
+              - key: "inventory.csv"
+                path: "inventory.csv"
+        - name: pysnmp-cache-volume
+          emptyDir: {}    
+        - name: tmp
+          emptyDir: {}                        
+      restartPolicy: OnFailure

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-config.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-config.yaml
@@ -1,0 +1,29 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-ha-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    dir /data
+
+    # Persistence
+    save 900 1
+    save 300 10
+    save 60 10000
+    appendonly yes
+    appendfsync everysec
+
+    # Replication
+    min-replicas-to-write 1
+    min-replicas-max-lag 10
+
+    loglevel notice
+    maxmemory-policy noeviction
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-service.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-service.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-ha-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-ha-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis-headless
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  clusterIP: None
+  ports:
+  - port: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
@@ -1,0 +1,139 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-ha
+  namespace: default
+  labels:
+    app: release-name-redis
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: database
+spec:
+  serviceName: release-name-redis-headless
+  replicas: 3
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "Fixing permissions on /data..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          ls -ln /data
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: release-name-redis-secret
+              key: password
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          cp /etc/redis/redis.conf /tmp/redis.conf
+          echo "requirepass $REDIS_PASSWORD" >> /tmp/redis.conf
+          echo "masterauth $REDIS_PASSWORD" >> /tmp/redis.conf
+
+          # Announce pod IP for Sentinel
+          echo "replica-announce-ip $POD_IP" >> /tmp/redis.conf
+          echo "replica-announce-port 6379" >> /tmp/redis.conf
+
+          # Start Redis
+          # Sentinel will handle promotion - all start as replicas initially
+          HOSTNAME=$(hostname)
+          MASTER_NAME="release-name-redis-ha-0"
+          MASTER_HOST="$MASTER_NAME.release-name-redis-headless"
+
+          if [ "$HOSTNAME" = "$MASTER_NAME" ]; then
+            echo "Starting as master"
+          else
+            echo "replicaof $MASTER_HOST 6379" >> /tmp/redis.conf
+            echo "Starting as replica of $MASTER_HOST"
+          fi
+
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli -a "$REDIS_PASSWORD" ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli -a "$REDIS_PASSWORD" ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
@@ -95,12 +95,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-secret.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-secret.yaml
@@ -1,0 +1,10 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-name-redis-secret
+  namespace: default
+type: Opaque
+data:
+  password: Y2hhbmdlbWUy

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-config.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-config.yaml
@@ -1,0 +1,20 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-sentinel-config
+  namespace: default
+  labels:
+    app: release-name-redis-sentinel
+data:
+  sentinel.conf: |
+    port 26379
+    dir /data
+    sentinel resolve-hostnames yes
+    sentinel announce-hostnames yes
+    sentinel monitor ${REDIS_MASTER_NAME} release-name-redis-ha-0.release-name-redis-headless 6379 2
+    sentinel auth-pass ${REDIS_MASTER_NAME} ${REDIS_PASSWORD}
+    sentinel down-after-milliseconds ${REDIS_MASTER_NAME} 5000
+    sentinel parallel-syncs ${REDIS_MASTER_NAME} 1
+    sentinel failover-timeout ${REDIS_MASTER_NAME} 10000

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
@@ -41,11 +41,29 @@ spec:
           echo "Starting Redis Sentinel..."
           exec redis-sentinel /data/sentinel.conf
         env:
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: release-name-redis-secret
-              key: password
+          - name: REDIS_MODE
+            value: "replication"
+          - name: REDIS_SENTINEL_SERVICE
+            value: release-name-redis-sentinel
+          - name: REDIS_HEADLESS_SERVICE
+            value: release-name-redis-headless
+          - name: NAMESPACE
+            value: default
+          - name: REDIS_SENTINEL_REPLICAS
+            value: "3"
+          - name: REDIS_SENTINEL_PORT
+            value: "26379"
+          - name: REDIS_MASTER_NAME
+            value: mymaster
+          - name: REDIS_DB
+            value: "1"
+          - name: CELERY_DB
+            value: "0"
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: release-name-redis-secret
+                key: password
         volumeMounts:
         - name: sentinel-config
           mountPath: /etc/redis

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
@@ -1,0 +1,82 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-sentinel
+  namespace: default
+  labels:
+    app: release-name-redis-sentinel
+    app.kubernetes.io/component: sentinel
+spec:
+  serviceName: release-name-redis-sentinel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: release-name-redis-sentinel
+  template:
+    metadata:
+      labels:
+        app: release-name-redis-sentinel
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+    spec:
+      containers:
+      - name: sentinel
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 26379
+          name: sentinel
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          cp /etc/redis/sentinel.conf /data/sentinel.conf
+          sed -i "s/\${REDIS_MASTER_NAME}/$REDIS_MASTER_NAME/g" /data/sentinel.conf
+          sed -i "s/\${REDIS_PASSWORD}/$REDIS_PASSWORD/g" /data/sentinel.conf
+
+          echo "Starting Redis Sentinel..."
+          exec redis-sentinel /data/sentinel.conf
+        env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: release-name-redis-secret
+              key: password
+        volumeMounts:
+        - name: sentinel-config
+          mountPath: /etc/redis
+        - name: sentinel-data
+          mountPath: /data
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - redis-cli -p 26379 ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - redis-cli -p 26379 sentinel get-master-addr-by-name ${REDIS_MASTER_NAME}
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: sentinel-config
+        configMap:
+          name: release-name-redis-sentinel-config
+      - name: sentinel-data
+        emptyDir: {}

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/sentinel-headless-service.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/sentinel-headless-service.yaml
@@ -1,0 +1,19 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/sentinel/sentinel-headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis-sentinel
+  namespace: default
+  labels:
+    app: release-name-redis-sentinel
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless - required by StatefulSet
+  publishNotReadyAddresses: true  # Allow Sentinel discovery before ready
+  ports:
+  - port: 26379
+    targetPort: 26379
+    name: sentinel
+  selector:
+    app: release-name-redis-sentinel

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -1,0 +1,118 @@
+---
+# Source: splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-splunk-connect-for-snmp-scheduler
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+      labels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: release-name-splunk-connect-for-snmp-user
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: splunk-connect-for-snmp-scheduler
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
+          imagePullPolicy: Always
+          args:
+            [
+              "celery", "beat",
+            ]          
+          env:
+            - name: CONFIG_PATH
+              value: /app/config/config.yaml
+            - name: REDIS_MODE
+              value: "replication"
+            - name: REDIS_SENTINEL_SERVICE
+              value: release-name-redis-sentinel
+            - name: REDIS_HEADLESS_SERVICE
+              value: release-name-redis-headless
+            - name: NAMESPACE
+              value: default
+            - name: REDIS_SENTINEL_REPLICAS
+              value: "3"
+            - name: REDIS_SENTINEL_PORT
+              value: "26379"
+            - name: REDIS_MASTER_NAME
+              value: mymaster
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-redis-secret
+                  key: password
+            - name: MONGO_URI
+              value: mongodb://release-name-mongodb:27017
+            - name: MIB_SOURCES
+              value: "http://release-name-mibserver/asn1/@mib@"
+            - name: MIB_INDEX
+              value: "http://release-name-mibserver/index.csv"
+            - name: MIB_STANDARD
+              value: "http://release-name-mibserver/standard.txt"
+            - name: LOG_LEVEL
+              value: INFO
+          volumeMounts:
+            - name: config
+              mountPath: "/app/config"
+              readOnly: true
+            - name: pysnmp-cache-volume
+              mountPath: "/.pysnmp/"
+              readOnly: false            
+            - name: tmp
+              mountPath: "/tmp/"
+              readOnly: false
+          resources:
+            {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                      app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+                      app.kubernetes.io/instance: release-name
+      volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: config
+          configMap:
+            # Provide the name of the ConfigMap you want to mount.
+            name: splunk-connect-for-snmp-config
+            # An array of keys from the ConfigMap to create as files
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: pysnmp-cache-volume
+          emptyDir: {}    
+        - name: tmp
+          emptyDir: {}

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/scheduler/pdb.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/scheduler/pdb.yaml
@@ -1,0 +1,18 @@
+---
+# Source: splunk-connect-for-snmp/templates/scheduler/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-splunk-connect-for-snmp-scheduler
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-scheduler
+        app.kubernetes.io/instance: release-name

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/serviceaccount.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+---
+# Source: splunk-connect-for-snmp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-name-splunk-connect-for-snmp-user
+  labels:
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/sim/pdb.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/sim/pdb.yaml
@@ -1,0 +1,18 @@
+---
+# Source: splunk-connect-for-snmp/templates/sim/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-splunk-connect-for-snmp-sim
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-sim
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minAvailable: 80%
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-sim
+        app.kubernetes.io/instance: release-name

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -1,0 +1,35 @@
+---
+# Source: splunk-connect-for-snmp/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "release-name-splunk-connect-for-snmp-trap-test-connection"
+  labels:
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "kube-score/ignore": "pod-probes,pod-networkpolicy"
+spec:
+  containers:
+    - name: wget
+      image: busybox:1.34.1
+      imagePullPolicy: Always
+      command: ['wget']
+      args: ['release-name-splunk-connect-for-snmp-trap:162']
+      securityContext:
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi            
+  restartPolicy: Never

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -1,0 +1,146 @@
+---
+# Source: splunk-connect-for-snmp/templates/traps/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-splunk-connect-for-snmp-trap
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-trap
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: splunk-connect-for-snmp-trap
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+      labels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-trap
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: release-name-splunk-connect-for-snmp-user
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: splunk-connect-for-snmp-traps
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
+          imagePullPolicy: Always
+          args:
+            [
+              "trap"
+            ] 
+          env:
+            - name: CONFIG_PATH
+              value: /app/config/config.yaml
+            - name: MONGO_URI
+              value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "replication"
+            - name: REDIS_SENTINEL_SERVICE
+              value: release-name-redis-sentinel
+            - name: REDIS_HEADLESS_SERVICE
+              value: release-name-redis-headless
+            - name: NAMESPACE
+              value: default
+            - name: REDIS_SENTINEL_REPLICAS
+              value: "3"
+            - name: REDIS_SENTINEL_PORT
+              value: "26379"
+            - name: REDIS_MASTER_NAME
+              value: mymaster
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-redis-secret
+                  key: password
+            - name: MIB_SOURCES
+              value: "http://release-name-mibserver/asn1/@mib@"
+            - name: MIB_INDEX
+              value: "http://release-name-mibserver/index.csv"
+            - name: MIB_STANDARD
+              value: "http://release-name-mibserver/standard.txt"
+            - name: LOG_LEVEL
+              value: INFO
+            - name: DISABLE_MONGO_DEBUG_LOGGING
+              value: "true"
+            - name: PYSNMP_DEBUG
+              value: ""
+            - name: SPLUNK_HEC_SCHEME
+              value: "https"
+            - name: SPLUNK_HEC_HOST
+              value: "10.202.18.152"
+            - name: SPLUNK_HEC_PORT
+              value: "8088"
+            - name: SPLUNK_HEC_INSECURESSL
+              value: "true"
+            - name: INCLUDE_SECURITY_CONTEXT_ID
+              value: "false"
+            - name: SNMP_V3_SECURITY_ENGINE_ID
+              value: 80003a8c04
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom:
+                  secretKeyRef:
+                    name: splunk-connect-for-snmp-splunk
+                    key: hec_token
+            - name: IPv6_ENABLED
+              value: "false"
+          ports:
+            - name: snmp-udp
+              containerPort: 2162
+              protocol: UDP
+          volumeMounts:
+            - name: config
+              mountPath: "/app/config"
+              readOnly: true
+            - name: pysnmp-cache-volume
+              mountPath: "/.pysnmp/"
+              readOnly: false                
+            - name: tmp
+              mountPath: "/tmp/"
+              readOnly: false                    
+
+          resources:
+            {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                      app.kubernetes.io/name: splunk-connect-for-snmp-trap
+                      app.kubernetes.io/instance: release-name
+      volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: config
+          configMap:
+            # Provide the name of the ConfigMap you want to mount.
+            name: splunk-connect-for-snmp-traps
+            # An array of keys from the ConfigMap to create as files
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: pysnmp-cache-volume
+          emptyDir: {}    
+        - name: tmp
+          emptyDir: {}

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/pdb.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/pdb.yaml
@@ -1,0 +1,18 @@
+---
+# Source: splunk-connect-for-snmp/templates/traps/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-splunk-connect-for-snmp-trap
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-trap
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minAvailable: 80%
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-trap
+        app.kubernetes.io/instance: release-name

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/service.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/service.yaml
@@ -1,0 +1,30 @@
+---
+# Source: splunk-connect-for-snmp/templates/traps/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-splunk-connect-for-snmp-trap
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-trap
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "splunk-connect"
+    metallb.universe.tf/loadBalancerIPs: 10.202.6.213
+    
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+  - IPv4
+  ports:
+    - port: 162
+      targetPort: 2162
+      protocol: UDP
+      name: snmp-udp
+  selector:
+    app.kubernetes.io/name: splunk-connect-for-snmp-trap
+    app.kubernetes.io/instance: release-name

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/pdb.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/pdb.yaml
@@ -1,0 +1,18 @@
+---
+# Source: splunk-connect-for-snmp/templates/worker/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-splunk-connect-for-snmp-worker
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-worker
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minAvailable: 80%
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-worker
+        app.kubernetes.io/instance: release-name

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -1,0 +1,178 @@
+---
+# Source: splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-splunk-connect-for-snmp-worker-poller
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+      labels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: release-name-splunk-connect-for-snmp-user
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: splunk-connect-for-snmp-worker-poller
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
+          imagePullPolicy: Always
+          args:
+            [
+              "celery", "worker-poller",
+            ]
+          env:
+            - name: CONFIG_PATH
+              value: /app/config/config.yaml
+            - name: SC4SNMP_VERSION
+              value: CURRENT-VERSION
+            - name: REDIS_MODE
+              value: "replication"
+            - name: REDIS_SENTINEL_SERVICE
+              value: release-name-redis-sentinel
+            - name: REDIS_HEADLESS_SERVICE
+              value: release-name-redis-headless
+            - name: NAMESPACE
+              value: default
+            - name: REDIS_SENTINEL_REPLICAS
+              value: "3"
+            - name: REDIS_SENTINEL_PORT
+              value: "26379"
+            - name: REDIS_MASTER_NAME
+              value: mymaster
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-redis-secret
+                  key: password
+            - name: MONGO_URI
+              value: mongodb://release-name-mongodb:27017
+            - name: WALK_RETRY_MAX_INTERVAL
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
+            - name: METRICS_INDEXING_ENABLED
+              value: "false"
+            - name: POLL_BASE_PROFILES
+              value: "true"
+            - name: LOG_LEVEL
+              value: INFO
+            - name: DISABLE_MONGO_DEBUG_LOGGING
+              value: "true"
+            - name: UDP_CONNECTION_TIMEOUT
+              value: "3"
+            - name: MAX_OID_TO_PROCESS
+              value: "70"
+            - name: MAX_REPETITIONS
+              value: "10"
+            - name: PYSNMP_DEBUG
+              value: ""
+            - name: PROFILES_RELOAD_DELAY
+              value: "60"
+            - name: MIB_SOURCES
+              value: "http://release-name-mibserver/asn1/@mib@"
+            - name: MIB_INDEX
+              value: "http://release-name-mibserver/index.csv"
+            - name: MIB_STANDARD
+              value: "http://release-name-mibserver/standard.txt"
+            - name: SPLUNK_HEC_SCHEME
+              value: "https"
+            - name: SPLUNK_HEC_HOST
+              value: "10.202.18.152"
+            - name: IGNORE_EMPTY_VARBINDS
+              value: "false"
+            - name: SPLUNK_HEC_PORT
+              value: "8088"
+            - name: SPLUNK_HEC_INSECURESSL
+              value: "true"
+            - name: SPLUNK_AGGREGATE_TRAPS_EVENTS
+              value: "false"
+            - name: SPLUNK_METRIC_NAME_HYPHEN_TO_UNDERSCORE
+              value: "false"
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: splunk-connect-for-snmp-splunk
+                  key: hec_token
+            - name: SPLUNK_HEC_INDEX_EVENTS
+              value: netops
+            - name: SPLUNK_HEC_INDEX_METRICS
+              value: netmetrics
+            - name: SPLUNK_SOURCETYPE_TRAPS
+              value: "sc4snmp:traps"
+            - name: SPLUNK_SOURCETYPE_POLLING_EVENTS
+              value: "sc4snmp:event"
+            - name: SPLUNK_SOURCETYPE_POLLING_METRICS
+              value: "sc4snmp:metric"
+            - name: WORKER_CONCURRENCY
+              value: "4"
+            - name: PREFETCH_COUNT
+              value: "1"
+            - name: IPv6_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: "/app/config"
+              readOnly: true
+            - name: pysnmp-cache-volume
+              mountPath: "/.pysnmp/"
+              readOnly: false
+            - name: tmp
+              mountPath: "/tmp/"
+              readOnly: false
+          resources:
+            limits:
+              cpu: 500m
+            requests:
+              cpu: 250m
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                      app.kubernetes.io/name: splunk-connect-for-snmp-worker-poller
+                      app.kubernetes.io/instance: release-name
+      volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: config
+          configMap:
+            # Provide the name of the ConfigMap you want to mount.
+            name: splunk-connect-for-snmp-config
+            # An array of keys from the ConfigMap to create as files
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: pysnmp-cache-volume
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -1,0 +1,176 @@
+---
+# Source: splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-splunk-connect-for-snmp-worker-sender
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+      labels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: release-name-splunk-connect-for-snmp-user
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: splunk-connect-for-snmp-worker-sender
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
+          imagePullPolicy: Always
+          args:
+            [
+              "celery", "worker-sender",
+            ]
+          env:
+            - name: CONFIG_PATH
+              value: /app/config/config.yaml
+            - name: SC4SNMP_VERSION
+              value: CURRENT-VERSION
+            - name: REDIS_MODE
+              value: "replication"
+            - name: REDIS_SENTINEL_SERVICE
+              value: release-name-redis-sentinel
+            - name: REDIS_HEADLESS_SERVICE
+              value: release-name-redis-headless
+            - name: NAMESPACE
+              value: default
+            - name: REDIS_SENTINEL_REPLICAS
+              value: "3"
+            - name: REDIS_SENTINEL_PORT
+              value: "26379"
+            - name: REDIS_MASTER_NAME
+              value: mymaster
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-redis-secret
+                  key: password
+            - name: MONGO_URI
+              value: mongodb://release-name-mongodb:27017
+            - name: WALK_RETRY_MAX_INTERVAL
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
+            - name: METRICS_INDEXING_ENABLED
+              value: "false"
+            - name: POLL_BASE_PROFILES
+              value: "true"
+            - name: LOG_LEVEL
+              value: INFO
+            - name: DISABLE_MONGO_DEBUG_LOGGING
+              value: "true"
+            - name: UDP_CONNECTION_TIMEOUT
+              value: "3"
+            - name: MAX_OID_TO_PROCESS
+              value: "70"
+            - name: MAX_REPETITIONS
+              value: "10"
+            - name: PYSNMP_DEBUG
+              value: ""
+            - name: PROFILES_RELOAD_DELAY
+              value: "60"
+            - name: MIB_SOURCES
+              value: "http://release-name-mibserver/asn1/@mib@"
+            - name: MIB_INDEX
+              value: "http://release-name-mibserver/index.csv"
+            - name: MIB_STANDARD
+              value: "http://release-name-mibserver/standard.txt"
+            - name: SPLUNK_HEC_SCHEME
+              value: "https"
+            - name: SPLUNK_HEC_HOST
+              value: "10.202.18.152"
+            - name: IGNORE_EMPTY_VARBINDS
+              value: "false"
+            - name: SPLUNK_HEC_PORT
+              value: "8088"
+            - name: SPLUNK_HEC_INSECURESSL
+              value: "true"
+            - name: SPLUNK_AGGREGATE_TRAPS_EVENTS
+              value: "false"
+            - name: SPLUNK_METRIC_NAME_HYPHEN_TO_UNDERSCORE
+              value: "false"
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: splunk-connect-for-snmp-splunk
+                  key: hec_token
+            - name: SPLUNK_HEC_INDEX_EVENTS
+              value: netops
+            - name: SPLUNK_HEC_INDEX_METRICS
+              value: netmetrics
+            - name: SPLUNK_SOURCETYPE_TRAPS
+              value: "sc4snmp:traps"
+            - name: SPLUNK_SOURCETYPE_POLLING_EVENTS
+              value: "sc4snmp:event"
+            - name: SPLUNK_SOURCETYPE_POLLING_METRICS
+              value: "sc4snmp:metric"
+            - name: WORKER_CONCURRENCY
+              value: "4"
+            - name: PREFETCH_COUNT
+              value: "30"
+          volumeMounts:
+            - name: config
+              mountPath: "/app/config"
+              readOnly: true
+            - name: pysnmp-cache-volume
+              mountPath: "/.pysnmp/"
+              readOnly: false
+            - name: tmp
+              mountPath: "/tmp/"
+              readOnly: false
+          resources:
+            limits:
+              cpu: 500m
+            requests:
+              cpu: 250m
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                      app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
+                      app.kubernetes.io/instance: release-name
+      volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: config
+          configMap:
+            # Provide the name of the ConfigMap you want to mount.
+            name: splunk-connect-for-snmp-config
+            # An array of keys from the ConfigMap to create as files
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: pysnmp-cache-volume
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -1,0 +1,184 @@
+---
+# Source: splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-splunk-connect-for-snmp-worker-trap
+  labels:
+    app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
+    app.kubernetes.io/instance: release-name
+    helm.sh/chart: splunk-connect-for-snmp-CURRENT-VERSION
+    app.kubernetes.io/version: "CURRENT-VERSION"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
+        checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
+      labels:
+        app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: release-name-splunk-connect-for-snmp-user
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: splunk-connect-for-snmp-worker-trap
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+          image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
+          imagePullPolicy: Always
+          args:
+            [
+              "celery", "worker-trap",
+            ]
+          env:
+            - name: CONFIG_PATH
+              value: /app/config/config.yaml
+            - name: SC4SNMP_VERSION
+              value: CURRENT-VERSION
+            - name: REDIS_MODE
+              value: "replication"
+            - name: REDIS_SENTINEL_SERVICE
+              value: release-name-redis-sentinel
+            - name: REDIS_HEADLESS_SERVICE
+              value: release-name-redis-headless
+            - name: NAMESPACE
+              value: default
+            - name: REDIS_SENTINEL_REPLICAS
+              value: "3"
+            - name: REDIS_SENTINEL_PORT
+              value: "26379"
+            - name: REDIS_MASTER_NAME
+              value: mymaster
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-redis-secret
+                  key: password
+            - name: MONGO_URI
+              value: mongodb://release-name-mongodb:27017
+            - name: WALK_RETRY_MAX_INTERVAL
+              value: "180"
+            - name: WALK_MAX_RETRIES
+              value: "5"
+            - name: METRICS_INDEXING_ENABLED
+              value: "false"
+            - name: POLL_BASE_PROFILES
+              value: "true"
+            - name: LOG_LEVEL
+              value: INFO
+            - name: DISABLE_MONGO_DEBUG_LOGGING
+              value: "true"
+            - name: UDP_CONNECTION_TIMEOUT
+              value: "3"
+            - name: MAX_OID_TO_PROCESS
+              value: "70"
+            - name: MAX_REPETITIONS
+              value: "10"
+            - name: PYSNMP_DEBUG
+              value: ""
+            - name: PROFILES_RELOAD_DELAY
+              value: "60"
+            - name: MIB_SOURCES
+              value: "http://release-name-mibserver/asn1/@mib@"
+            - name: MIB_INDEX
+              value: "http://release-name-mibserver/index.csv"
+            - name: MIB_STANDARD
+              value: "http://release-name-mibserver/standard.txt"
+            - name: SPLUNK_HEC_SCHEME
+              value: "https"
+            - name: SPLUNK_HEC_HOST
+              value: "10.202.18.152"
+            - name: IGNORE_EMPTY_VARBINDS
+              value: "false"
+            - name: SPLUNK_HEC_PORT
+              value: "8088"
+            - name: SPLUNK_HEC_INSECURESSL
+              value: "true"
+            - name: SPLUNK_AGGREGATE_TRAPS_EVENTS
+              value: "false"
+            - name: SPLUNK_METRIC_NAME_HYPHEN_TO_UNDERSCORE
+              value: "false"
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: splunk-connect-for-snmp-splunk
+                  key: hec_token
+            - name: SPLUNK_HEC_INDEX_EVENTS
+              value: netops
+            - name: SPLUNK_HEC_INDEX_METRICS
+              value: netmetrics
+            - name: SPLUNK_SOURCETYPE_TRAPS
+              value: "sc4snmp:traps"
+            - name: SPLUNK_SOURCETYPE_POLLING_EVENTS
+              value: "sc4snmp:event"
+            - name: SPLUNK_SOURCETYPE_POLLING_METRICS
+              value: "sc4snmp:metric"
+            - name: WORKER_CONCURRENCY
+              value: "4"
+            - name: PREFETCH_COUNT
+              value: "30"
+            - name: RESOLVE_TRAP_ADDRESS
+              value: "false"
+            - name: MAX_DNS_CACHE_SIZE_TRAPS
+              value: "500"
+            - name: TTL_DNS_CACHE_TRAPS
+              value: "1800"
+            - name: IPv6_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: "/app/config"
+              readOnly: true
+            - name: pysnmp-cache-volume
+              mountPath: "/.pysnmp/"
+              readOnly: false
+            - name: tmp
+              mountPath: "/tmp/"
+              readOnly: false
+          resources:
+            limits:
+              cpu: 500m
+            requests:
+              cpu: 250m
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                      app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
+                      app.kubernetes.io/instance: release-name
+      volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: config
+          configMap:
+            # Provide the name of the ConfigMap you want to mount.
+            name: splunk-connect-for-snmp-config
+            # An array of keys from the ConfigMap to create as files
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: pysnmp-cache-volume
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-config.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-config.yaml
@@ -1,0 +1,33 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-redis-config
+  namespace: default
+  labels:
+    app: release-name-redis
+data:
+  redis.conf: |
+    # Data directory
+    dir /data
+
+    # Persistence - RDB
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Persistence - AOF
+    appendonly yes
+    appendfsync everysec
+
+    # Logging
+    loglevel notice
+
+    # Memory
+    maxmemory-policy noeviction
+
+    # Network
+    bind 0.0.0.0
+    protected-mode no
+    port 6379

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-redis
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+  selector:
+    app: release-name-redis

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -70,12 +70,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 250m
-            memory: 256Mi
+          {}
         livenessProbe:
           exec:
             command:

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-redis-standalone
+  namespace: default
+  labels:
+    app: release-name-redis
+spec:
+  serviceName: release-name-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: release-name-redis
+  template:
+    metadata:
+      labels:
+        app: release-name-redis
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
+    spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
+      initContainers:
+      - name: fix-permissions
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          echo "=== Redis Init: Fixing Permissions ==="
+          echo "Current ownership:"
+          ls -ln /data
+          echo ""
+          echo "Fixing ownership to 999:999..."
+          chown -R 999:999 /data
+          chmod -R 755 /data
+          echo ""
+          echo "New ownership:"
+          ls -ln /data
+          echo "=== Permissions Fixed ==="
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        securityContext:
+          runAsUser: 0  # Must run as root to chown
+      containers:
+      - name: redis
+        image: redis:8.2.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - sh
+        - -c
+        args:
+        - |
+          # Copy config to writable location
+          cp /etc/redis/redis.conf /tmp/redis.conf
+
+          # Start Redis
+          exec redis-server /tmp/redis.conf
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        - name: redis-config
+          mountPath: /etc/redis
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |
+              redis-cli ping
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      # Storage enabled but no existing PVC - use volumeClaimTemplates below
+      volumes:
+      - name: redis-config
+        configMap:
+          name: release-name-redis-config
+  # No existing PVC found, create new one via volumeClaimTemplates
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: 
+        - ReadWriteOnce
+      storageClassName: microk8s-hostpath
+      resources:
+        requests:
+          storage: 5Gi

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-trap
         app.kubernetes.io/instance: release-name
@@ -44,10 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MIB_SOURCES
               value: "http://release-name-mibserver/asn1/@mib@"
             - name: MIB_INDEX

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-sender
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp-worker-trap
         app.kubernetes.io/instance: release-name
@@ -44,12 +46,18 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /app/config/config.yaml
-            - name: REDIS_URL
-              value: redis://release-name-redis-master:6379/1
             - name: SC4SNMP_VERSION
               value: CURRENT-VERSION
-            - name: CELERY_BROKER_URL
-              value: redis://release-name-redis-master:6379/0
+            - name: REDIS_MODE
+              value: "standalone"
+            - name: REDIS_HOST
+              value: release-name-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "1"
+            - name: CELERY_DB
+              value: "0"
             - name: MONGO_URI
               value: mongodb://release-name-mongodb:27017
             - name: WALK_RETRY_MAX_INTERVAL

--- a/rendered/values_redis_ha.yaml
+++ b/rendered/values_redis_ha.yaml
@@ -1,0 +1,50 @@
+splunk:
+  enabled: true
+  protocol: https
+  host: 10.202.18.152
+  token: 00000000-0000-0000-0000-000000000000
+  insecureSSL: "true"
+  port: "8088"
+traps:
+  communities:
+    2c:
+      - public
+      - homelab
+  #loadBalancerIP: The IP address in the metallb pool
+  loadBalancerIP: 10.202.6.213
+scheduler:
+  profiles: |
+    IF_profile:
+      frequency: 600
+      varBinds:
+        - [ "IF-MIB", "ifDescr" ]
+        - [ "IF-MIB", "ifAdminStatus" ]
+        - [ "IF-MIB", "ifName" ]
+        - [ 'IF-MIB','ifAlias' ]
+        - [ "IF-MIB", "ifInDiscards" ]
+        - [ "IF-MIB", "ifInErrors" ]
+        - [ "IF-MIB", "ifInNUcastPkts" ]
+        - [ "IF-MIB", "ifInOctets" ]
+        - [ "IF-MIB", "ifInUcastPkts" ]
+        - [ "IF-MIB", "ifInUnknownProtos" ]
+        - [ "IF-MIB", "ifOutDiscards" ]
+        - [ "IF-MIB", "ifOutErrors" ]
+        - [ "IF-MIB", "ifOutNUcastPkts" ]
+        - [ "IF-MIB", "ifOutOctets" ]
+        - [ "IF-MIB", "ifOutQLen" ]
+        - [ "IF-MIB", "ifOutUcastPkts" ]
+poller:
+  inventory: |
+    address,port,version,community,secret,security_engine,walk_interval,profiles,smart_profiles,delete
+    54.82.41.24,,2c,public,,,1800,IF_profile,false,
+inventory:
+  podAnnotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+redis:
+  architecture: replication
+  replicas: 3
+  sentinel:
+    enabled: true
+  auth:
+    enabled: true
+    password: "changeme2"

--- a/ui_tests/config/ui_values.yaml
+++ b/ui_tests/config/ui_values.yaml
@@ -3,12 +3,12 @@ UI:
   frontEnd:
     NodePort: 30001
     repository: ghcr.io/splunk/sc4snmp-ui/frontend/container
-    tag: "develop"
+    tag: "1.1.2-beta.1"
     pullPolicy: "Always"
   backEnd:
     NodePort: 30002
     repository: ghcr.io/splunk/sc4snmp-ui/backend/container
-    tag: "develop"
+    tag: "1.1.2-beta.1"
     pullPolicy: "Always"
   init:
     image: registry.access.redhat.com/ubi9/ubi

--- a/ui_tests/config/ui_values.yaml
+++ b/ui_tests/config/ui_values.yaml
@@ -3,12 +3,12 @@ UI:
   frontEnd:
     NodePort: 30001
     repository: ghcr.io/splunk/sc4snmp-ui/frontend/container
-    tag: "1.1.1"
+    tag: "develop"
     pullPolicy: "Always"
   backEnd:
     NodePort: 30002
     repository: ghcr.io/splunk/sc4snmp-ui/backend/container
-    tag: "1.1.1"
+    tag: "develop"
     pullPolicy: "Always"
   init:
     image: registry.access.redhat.com/ubi9/ubi


### PR DESCRIPTION
# Description

This PR adds HA Sentinel option to Redis component. Some of the main changes:
1. Initialise all redis env variables in `construct-redis-url.sh`
2. Add `replication` option to `redis.mode`
3. Add readiness and liveness probe
4. Add annotations to retrigger all pods whenever secrets change

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Refactor/improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings