### PR TITLE
fix: set empty priv for snmpv3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 - fix problem with service rendering when `traps.service.usemetallb` is set to false
+- fix setting snmpv3 to be able to set secret without privProtocol and privKey
 
 ## [1.14.1]
 - update mongodb volumePermission image repository to `bitnamileagcy`

--- a/docker_scripts/manage_secrets.py
+++ b/docker_scripts/manage_secrets.py
@@ -6,6 +6,9 @@ import sys
 BASE_DIR = "/app/secrets/snmpv3"
 SECRETS_JSON = "/app/secrets/tmp/secrets.json"
 
+# Define which fields are optional
+OPTIONAL_FIELDS = {"contextengineid", "privkey", "privprotocol"}
+
 
 def create_secret_files(secrets):
     file_map = {
@@ -21,14 +24,21 @@ def create_secret_files(secrets):
         secret_dir = os.path.join(BASE_DIR, secretname)
         skip = False
         for key, value in details.items():
-            if key.lower() != "contextengineid" and not value:
-                print(f"Skipping {secretname} as value {key} is not set.")
+            # Skip validation for optional fields
+            if key.lower() in OPTIONAL_FIELDS:
+                continue
+            # Check if required fields have values
+            if not value:
+                print(f"Skipping {secretname} as required value {key} is not set.")
                 skip = True
+                break
+
         if not skip:
             os.makedirs(secret_dir, exist_ok=True)
             for key, value in details.items():
                 file_name = file_map.get(key.lower())
-                if file_name:
+                # Only write files if the value exists or it's not an optional field
+                if file_name and value:
                     file_path = os.path.join(secret_dir, file_name)
                     with open(file_path, "w") as f:
                         f.write(str(value))
@@ -39,6 +49,12 @@ def create_secret_files(secrets):
 
 def delete_secret_files(secret_names):
     new_secret_names = set(secret_names)
+
+    # Check if BASE_DIR exists before listing
+    if not os.path.exists(BASE_DIR):
+        print(f"Base directory {BASE_DIR} does not exist. Nothing to delete.")
+        return
+
     existing_secret_dirs = set(os.listdir(BASE_DIR))
 
     # Remove directories of the secrets that are not provided

--- a/docs/dockercompose/5-traps-configuration.md
+++ b/docs/dockercompose/5-traps-configuration.md
@@ -9,7 +9,7 @@ usernameSecrets: []
 ```
 
 - `communities`: communities used for version `1` and `2c` of the snmp. The default one is `public`.
-- `usernameSecrets`: names of the secrets configured in docker used for `snmp v3` traps. 
+- `usernameSecrets`: names of the secrets configured in docker used for `snmpv3` traps. 
 
 ## Example of the configuration
 

--- a/docs/dockercompose/5-traps-configuration.md
+++ b/docs/dockercompose/5-traps-configuration.md
@@ -4,29 +4,29 @@ Traps configuration is stored in the `traps-config.yaml` file. This file has the
 ```yaml
 communities:
   2c:
-    public:
-      communityIndex:
-      contextEngineId:
-      contextName:
-      tag:
-      securityName:
+    - public
 usernameSecrets: []
 ```
 
 - `communities`: communities used for version `1` and `2c` of the snmp. The default one is `public`.
-- `usernameSecrets`: names of the secrets configured in docker used for `snmp v3` traps .
+- `usernameSecrets`: names of the secrets configured in docker used for `snmp v3` traps. 
 
 ## Example of the configuration
 
 ```yaml
 communities:
   2c:
-    public:
-      communityIndex:
-      contextEngineId:
-      contextName:
-      tag:
-      securityName:
+    - public
 usernameSecrets: 
   - my_secret
 ```
+
+## Prerequisites for SNMPv3 Configuration
+
+### Create the SNMPv3 Secret in Docker
+Before using SNMPv3, you must create the required secret within Docker. For detailed instructions, refer to [SNMPv3 secrets](7-snmpv3-secrets.md).
+
+### Configure the Security Engine ID
+To enable SNMPv3 functionality, the Security Engine ID must be specified. Please follow the guidelines in the 
+[Traps Section of the .env File Configuration](6-env-file-configuration.md#traps) for instructions on setting this value.
+

--- a/docs/dockercompose/7-snmpv3-secrets.md
+++ b/docs/dockercompose/7-snmpv3-secrets.md
@@ -42,7 +42,7 @@ Inside this folder, create a secrets.json file that contains all SNMPv3 secrets.
 }
 ```
 
-> **_NOTE:_** The name of json file should be secrets.json and secrets should have non-empty fields (except contextengineid).
+> **_NOTE:_** The name of json file should be secrets.json. Username, authprotocol and authkey are mandatory parameters.
 
 ## Configuration
 In the .env file, set the path to the local folder containing the secrets.json:

--- a/splunk_connect_for_snmp/traps.py
+++ b/splunk_connect_for_snmp/traps.py
@@ -246,8 +246,12 @@ def main():
                 location, "userName", required=True, default=None
             )
 
-            auth_key = get_secret_value(location, "authKey", required=False)
-            priv_key = get_secret_value(location, "privKey", required=False)
+            auth_key = get_secret_value(
+                location, "authKey", required=False, default=None
+            )
+            priv_key = get_secret_value(
+                location, "privKey", required=False, default=None
+            )
 
             auth_protocol = get_secret_value(location, "authProtocol", required=False)
             logger.debug(f"authProtocol: {auth_protocol}")
@@ -270,8 +274,8 @@ def main():
                     securityEngineId=v2c.OctetString(hexValue=security_engine_id),
                 )
                 logger.debug(
-                    f"V3 users: {username} auth {auth_protocol} authkey {len(auth_key)*'*'} privprotocol {priv_protocol} "
-                    f"privkey {len(priv_key)*'*'} securityEngineId {len(security_engine_id)*'*'}"
+                    f"V3 users: {username} auth {auth_protocol} authkey {len(str(auth_key))*'*'} privprotocol {priv_protocol} "
+                    f"privkey {len(str(priv_key))*'*'} securityEngineId {len(security_engine_id)*'*'}"
                 )
 
     # Register SNMP Application at the SNMP engine


### PR DESCRIPTION
# Description

Fix for #1322. Adding possibility to create snmpv3 secret without priv protocol set.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Dependency update
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

manual, integration

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings