### PR TITLE
Fix: inventory error in dc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 - fix problem with service rendering when `traps.service.usemetallb` is set to false
 - fix setting snmpv3 to be able to set secret without privProtocol and privKey
+- fix add error handling for inventory.csv misconfigured as dir
 
 ## [1.14.1]
 - update mongodb volumePermission image repository to `bitnamileagcy`

--- a/splunk_connect_for_snmp/common/inventory_processor.py
+++ b/splunk_connect_for_snmp/common/inventory_processor.py
@@ -130,19 +130,19 @@ class InventoryProcessor:
                 )
                 return [], {}
 
-            for inventory_line in ir_reader:
-                self.process_line(inventory_line)
-            for source_record in self.single_hosts:
-                address = source_record["address"]
-                port = source_record.get("port")
-                host = transform_address_to_key(address, port)
-                was_present = self.hosts_from_groups.get(host, None)
-                if was_present is None:
-                    self.inventory_records.append(source_record)
-                else:
-                    logger.warning(
-                        f"Record: {host} has been already configured in group. Skipping..."
-                    )
+        for inventory_line in ir_reader:
+            self.process_line(inventory_line)
+        for source_record in self.single_hosts:
+            address = source_record["address"]
+            port = source_record.get("port")
+            host = transform_address_to_key(address, port)
+            was_present = self.hosts_from_groups.get(host, None)
+            if was_present is None:
+                self.inventory_records.append(source_record)
+            else:
+                logger.warning(
+                    f"Record: {host} has been already configured in group. Skipping..."
+                )
         return self.inventory_records, self.inventory_group_port_mapping
 
     def process_line(self, source_record):

--- a/splunk_connect_for_snmp/common/inventory_processor.py
+++ b/splunk_connect_for_snmp/common/inventory_processor.py
@@ -123,26 +123,27 @@ class InventoryProcessor:
                     logger.info(f"Loading inventory from {INVENTORY_PATH}")
                     ir_reader = list(DictReader(csv_file))
 
-                for inventory_line in ir_reader:
-                    self.process_line(inventory_line)
-                for source_record in self.single_hosts:
-                    address = source_record["address"]
-                    port = source_record.get("port")
-                    host = transform_address_to_key(address, port)
-                    was_present = self.hosts_from_groups.get(host, None)
-                    if was_present is None:
-                        self.inventory_records.append(source_record)
-                    else:
-                        logger.warning(
-                            f"Record: {host} has been already configured in group. Skipping..."
-                        )
             except IsADirectoryError:
                 logger.error(
                     f"Inventory file {INVENTORY_PATH} not correctly created in the deployment.",
                     exc_info=True,
                 )
-            finally:
-                return self.inventory_records, self.inventory_group_port_mapping
+                return [], {}
+
+            for inventory_line in ir_reader:
+                self.process_line(inventory_line)
+            for source_record in self.single_hosts:
+                address = source_record["address"]
+                port = source_record.get("port")
+                host = transform_address_to_key(address, port)
+                was_present = self.hosts_from_groups.get(host, None)
+                if was_present is None:
+                    self.inventory_records.append(source_record)
+                else:
+                    logger.warning(
+                        f"Record: {host} has been already configured in group. Skipping..."
+                    )
+        return self.inventory_records, self.inventory_group_port_mapping
 
     def process_line(self, source_record):
         address = source_record["address"]

--- a/splunk_connect_for_snmp/common/inventory_processor.py
+++ b/splunk_connect_for_snmp/common/inventory_processor.py
@@ -122,26 +122,27 @@ class InventoryProcessor:
                 with open(INVENTORY_PATH, encoding="utf-8") as csv_file:
                     logger.info(f"Loading inventory from {INVENTORY_PATH}")
                     ir_reader = list(DictReader(csv_file))
+
+                for inventory_line in ir_reader:
+                    self.process_line(inventory_line)
+                for source_record in self.single_hosts:
+                    address = source_record["address"]
+                    port = source_record.get("port")
+                    host = transform_address_to_key(address, port)
+                    was_present = self.hosts_from_groups.get(host, None)
+                    if was_present is None:
+                        self.inventory_records.append(source_record)
+                    else:
+                        logger.warning(
+                            f"Record: {host} has been already configured in group. Skipping..."
+                        )
             except IsADirectoryError:
                 logger.error(
                     f"Inventory file {INVENTORY_PATH} not correctly created in the deployment.",
                     exc_info=True,
                 )
-                ir_reader = []
-        for inventory_line in ir_reader:
-            self.process_line(inventory_line)
-        for source_record in self.single_hosts:
-            address = source_record["address"]
-            port = source_record.get("port")
-            host = transform_address_to_key(address, port)
-            was_present = self.hosts_from_groups.get(host, None)
-            if was_present is None:
-                self.inventory_records.append(source_record)
-            else:
-                logger.warning(
-                    f"Record: {host} has been already configured in group. Skipping..."
-                )
-        return self.inventory_records, self.inventory_group_port_mapping
+            finally:
+                return self.inventory_records, self.inventory_group_port_mapping
 
     def process_line(self, source_record):
         address = source_record["address"]

--- a/splunk_connect_for_snmp/common/inventory_processor.py
+++ b/splunk_connect_for_snmp/common/inventory_processor.py
@@ -118,9 +118,16 @@ class InventoryProcessor:
             logger.info("Loading inventory from inventory_ui collection")
             ir_reader = list(self.inventory_ui_collection.find({}, {"_id": 0}))
         else:
-            with open(INVENTORY_PATH, encoding="utf-8") as csv_file:
-                logger.info(f"Loading inventory from {INVENTORY_PATH}")
-                ir_reader = list(DictReader(csv_file))
+            try:
+                with open(INVENTORY_PATH, encoding="utf-8") as csv_file:
+                    logger.info(f"Loading inventory from {INVENTORY_PATH}")
+                    ir_reader = list(DictReader(csv_file))
+            except IsADirectoryError:
+                logger.error(
+                    f"Inventory file {INVENTORY_PATH} not correctly created in the deployment.",
+                    exc_info=True,
+                )
+                ir_reader = []
         for inventory_line in ir_reader:
             self.process_line(inventory_line)
         for source_record in self.single_hosts:


### PR DESCRIPTION
# Description

Solution to #1323. 
The issue is with the docker compose when the inventory.csv file is not existing. The docker will then create the file as directory, and our code would raise an exception, and restart the inventory container in a loop. The solution is to catch this specific error when it is created: IsADirectoryError, add the information in logs, and proceed as if the inventory file is empty. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

manually, integration

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings