### PR TITLE
chore: migrate from FOSSA to SRS configuration

### DIFF
--- a/srs.yaml
+++ b/srs.yaml
@@ -1,0 +1,12 @@
+# SRS configuration file
+# Generated from .fossa.yml
+#
+
+scan:
+  scanners:
+  - vuln
+  - license
+  skip-dirs:
+  - integration_tests
+  - test
+  - ui_tests


### PR DESCRIPTION
## Summary

This MR/PR adds a `srs.yaml` configuration file generated from the existing `.fossa.yml` configuration.

## What Changed

- Added `srs.yaml` with settings migrated from `.fossa.yml`
- Mapped FOSSA paths.exclude to SRS skip-dirs
- Mapped FOSSA targets.exclude (type + path) to SRS skip-files

## Next Steps

1. Review the generated `srs.yaml` configuration
2. Check warning comments for any unsupported features

[_Created by Sourcegraph batch change `skammari/migrate-fossa-to-srs`._](https://sourcegraph.splunkdev.net/users/skammari/batch-changes/migrate-fossa-to-srs)