### PR TITLE
chore: import issue on ui tests

### DIFF
--- a/ui_tests/conftest.py
+++ b/ui_tests/conftest.py
@@ -17,6 +17,27 @@ def pytest_addoption(parser):
         default="127.0.0.1",
         help="Device Simulator external IP",
     )
+    parser.addoption(
+        "--splunk-host",
+        action="store",
+        dest="splunk-host",
+        default="localhost",
+        help="Splunk host to connect to",
+    )
+    parser.addoption(
+        "--splunk-user",
+        action="store",
+        dest="splunk-user",
+        default="admin",
+        help="Splunk username for authentication",
+    )
+    parser.addoption(
+        "--splunk-password",
+        action="store",
+        dest="splunk-password",
+        default="changeme",
+        help="Splunk password for authentication",
+    )
 
 
 @pytest.fixture(scope="function")

--- a/ui_tests/conftest.py
+++ b/ui_tests/conftest.py
@@ -21,7 +21,7 @@ def pytest_addoption(parser):
         "--splunk-host",
         action="store",
         dest="splunk-host",
-        default="localhost",
+        default="127.0.0.1",
         help="Splunk host to connect to",
     )
     parser.addoption(

--- a/ui_tests/requirements.txt
+++ b/ui_tests/requirements.txt
@@ -1,4 +1,3 @@
-pytest-splunk-addon
 selenium
 webdriver_manager
 pyyaml

--- a/ui_tests/requirements.txt
+++ b/ui_tests/requirements.txt
@@ -1,3 +1,4 @@
+pytest
 selenium
 webdriver_manager
 pyyaml


### PR DESCRIPTION
# Description

Fixing error from ui test:
`ModuleNotFoundError: No module named 'splunk_cim_models'`

Removes pytest-splunk-addon library that was used only for adding the splunk flags to CLI options from 
conftest.py

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

ui tests

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings