### PR TITLE
fix: update out of index error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - fix reusing the snmp engine for snmpv3 calls
+- fix out of range error for varbinds without tuple index
 
 ## [1.15.0]
 

--- a/splunk_connect_for_snmp/snmp/manager.py
+++ b/splunk_connect_for_snmp/snmp/manager.py
@@ -241,7 +241,7 @@ def extract_index_number(index):
         return 0
     index_number = index[0]._value
     if isinstance(index_number, typing.Tuple):
-        index_number = index_number[0]
+        index_number = index_number[0] if index_number else 0
     return index_number
 
 


### PR DESCRIPTION
# Description

Fix the error `tuple index out of range` when processing the snmp data like:
`F5-BIGIP-LOCAL-MIB::ltmFwRuleStatCounter. = 0`
Now it should appear as: 
`F5-BIGIP-LOCAL-MIB::ltmFwRuleStatCounter.0 = 0`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

integration

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings