### PR TITLE
fix: oom issue on mongodb 8.x and kernel >=6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - add MAX_TASKS_PER_CHILD setting to celery workers
 
 ### Fixed
+- prevent MongoDB 8.x SIGSEGV on Linux kernel >= 6.19 by defaulting `GLIBC_TUNABLES=glibc.pthread.rseq=1` on the mongo container.
 
 [1.16.0]
 ### Changed

--- a/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-ha-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-ha-statefulset.yaml
@@ -80,8 +80,9 @@ spec:
         - containerPort: 27017
           name: mongodb
 
-        {{- if .Values.mongodb.auth.enabled }}
+        {{- if or .Values.mongodb.auth.enabled .Values.mongodb.extraEnv }}
         env:
+          {{- if .Values.mongodb.auth.enabled }}
           {{- if .Values.mongodb.auth.existingSecret }}
           - name: MONGO_INITDB_ROOT_USERNAME
             valueFrom:
@@ -104,7 +105,11 @@ spec:
               secretKeyRef:
                 name: {{ .Release.Name }}-mongodb-secret
                 key: root-password
-        {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.mongodb.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- end }}
 
         volumeMounts:

--- a/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -57,9 +57,10 @@ spec:
         - containerPort: 27017
           name: mongodb
 
-        {{- if .Values.mongodb.auth.enabled }}
+        {{- if or .Values.mongodb.auth.enabled .Values.mongodb.extraEnv }}
         env:
-         {{- if .Values.mongodb.auth.existingSecret }}
+          {{- if .Values.mongodb.auth.enabled }}
+          {{- if .Values.mongodb.auth.existingSecret }}
           - name: MONGO_INITDB_ROOT_USERNAME
             valueFrom:
               secretKeyRef:
@@ -81,7 +82,11 @@ spec:
               secretKeyRef:
                 name: {{ .Release.Name }}-mongodb-secret
                 key: root-password
-        {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.mongodb.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- end }}
 
         volumeMounts:

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -622,6 +622,13 @@ mongodb:
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
+
+  # Extra environment variables for the mongod container.
+  # The default GLIBC_TUNABLES entry mitigates a MongoDB 8.x SIGSEGV (exit 139)
+  # observed on host kernels >= 6.19 (e.g. Ubuntu 26.04).
+  extraEnv:
+    - name: GLIBC_TUNABLES
+      value: "glibc.pthread.rseq=1"
 redis:
   # Mode selector: "standalone", "replication"
   architecture: standalone

--- a/docker_compose/.env
+++ b/docker_compose/.env
@@ -28,6 +28,8 @@ REDIS_IMAGE=docker.io/redis
 REDIS_TAG=8.2.2
 MONGO_IMAGE=docker.io/mongo
 MONGO_TAG=8.2.2
+# Mitigates a MongoDB 8.x SIGSEGV observed on host kernels >= 6.19 (e.g. Ubuntu 26.04).
+MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1
 
 # Splunk instance configuration
 SPLUNK_HEC_HOST=

--- a/docker_compose/docker-compose.yaml
+++ b/docker_compose/docker-compose.yaml
@@ -112,6 +112,8 @@ services:
     <<: [*dns_and_networks, *dependend_on_core_dns]
     image: ${MONGO_IMAGE}:${MONGO_TAG:-latest}
     container_name: mongo
+    environment:
+      GLIBC_TUNABLES: ${MONGO_GLIBC_TUNABLES:-glibc.pthread.rseq=1}
   inventory:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}

--- a/docs/dockercompose/6-env-file-configuration.md
+++ b/docs/dockercompose/6-env-file-configuration.md
@@ -70,6 +70,7 @@ Once the required variables above are set, you can [Deploy the app](./11-deploy-
 | `REDIS_TAG`       | Redis image tag to pull              |
 | `MONGO_IMAGE`     | Registry and name of MongoDB image   |
 | `MONGO_TAG`       | MongoDB image tag to pull            |
+| `MONGO_GLIBC_TUNABLES` | Value passed as `GLIBC_TUNABLES` to the `mongo` container. Defaults to `glibc.pthread.rseq=1` to mitigate a MongoDB 8.x SIGSEGV observed on host kernels >= 6.19 (e.g. Ubuntu 26.04). Safe no-op on older kernels. See [MongoDB 8.x crash on Linux kernel 6.19+](../troubleshooting/general-issues.md#mongodb-8x-crash-on-linux-kernel-619-exit-139--sigsegv). |
 
 ### Splunk instance
 

--- a/docs/microk8s/configuration/mongo-configuration.md
+++ b/docs/microk8s/configuration/mongo-configuration.md
@@ -64,6 +64,11 @@ mongodb:
     capabilities:
       drop:
       - ALL
+
+  # Extra environment variables injected into the mongod container.
+  extraEnv:
+    - name: GLIBC_TUNABLES
+      value: "glibc.pthread.rseq=1"
 ```
 
 | Key                                        | Type   | Default        | Description                                                      |
@@ -93,6 +98,10 @@ mongodb:
 | mongodb.replicaInitJob.image.repository    | string | alpine/kubectl | Container image for the initialization job.                      |
 | mongodb.replicaInitJob.image.tag           | string | 1.34.2         | Image tag / kubectl version.                                     |
 | mongodb.replicaInitJob.timeout             | int    | 600            | Maximum time (in seconds) to wait for each pod to become ready.  |
+| mongodb.extraEnv                           | list   | `[{name: GLIBC_TUNABLES, value: "glibc.pthread.rseq=1"}]` | Extra environment variables injected into the mongod container. The default `GLIBC_TUNABLES` entry mitigates a MongoDB 8.x SIGSEGV observed on host kernels >= 6.19 (e.g. Ubuntu 26.04 / kernel 6.19+ HWE backports). See [MongoDB 8.x crash on Linux kernel 6.19+](../../troubleshooting/general-issues.md#mongodb-8x-crash-on-linux-kernel-619-exit-139--sigsegv). |
+
+!!!note "Extra environment variables (`mongodb.extraEnv`)"
+    `mongodb.extraEnv` is a list of standard Kubernetes env entries appended to the mongod container. It ships with a single default entry that sets `GLIBC_TUNABLES=glibc.pthread.rseq=1`, which restores the upstream glibc default and prevents a tcmalloc SIGSEGV (`exit 139`) that occurs ~30s after `startup complete` on host nodes running Linux kernel 6.19 or later. The setting is a no-op on kernels < 6.19. To override or extend the list, redefine `mongodb.extraEnv` in your `values.yaml`.
 
 ### Architecture Modes
 

--- a/docs/troubleshooting/general-issues.md
+++ b/docs/troubleshooting/general-issues.md
@@ -1,5 +1,60 @@
 ## General issues
 
+### MongoDB 8.x crash on Linux kernel 6.19+ (exit 139 / SIGSEGV)
+
+The `mongo:8.0.5+` and `mongo:8.2.x` images (the default since SC4SNMP `1.16.0`) bake a `GLIBC_TUNABLES=glibc.pthread.rseq=0` setting into the image. On host kernels >= 6.19, which overhauled the RSEQ subsystem, this setting causes MongoDB's `tcmalloc` allocator to crash. The `mongo` container logs `mongod startup complete`, runs for about 30 seconds, then exits with code `139` (SIGSEGV). `OOMKilled=false`, and the next start logs `Detected unclean shutdown - Lock file is not empty`.
+
+#### How to confirm
+
+Check the host kernel version:
+
+/// tab | docker compose
+```bash
+uname -r
+```
+///
+
+/// tab | microk8s
+```bash
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.nodeInfo.kernelVersion}{"\n"}{end}'
+```
+///
+
+Anything `>= 6.19` is at risk. Also check container exit state:
+
+```bash
+docker inspect mongo --format 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}'
+```
+
+The combination `exit=139 oom=false` together with `mongod startup complete` in the container logs ~30s before the exit is the diagnostic signature.
+
+#### Fix
+
+SC4SNMP from version **1.17.0** ships a default `GLIBC_TUNABLES=glibc.pthread.rseq=1` on the mongo container, which restores the upstream glibc default and prevents the crash. The setting is a safe no-op on kernels < 6.19, so it is enabled unconditionally. You normally do not need to do anything.
+
+If you previously customized the mongo container and removed/overrode the env variable, restore it:
+
+/// tab | docker compose
+In `docker_compose/.env`, ensure:
+
+```
+MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1
+```
+
+The `mongo` service in `docker-compose.yaml` already references this variable.
+///
+
+/// tab | microk8s
+In `values.yaml`, ensure the entry is present (it is the default):
+
+```yaml
+mongodb:
+  extraEnv:
+    - name: GLIBC_TUNABLES
+      value: "glibc.pthread.rseq=1"
+```
+///
+
 ### Upgrading SC4SNMP from 1.12.2 to 1.12.3
 
 !!! warning "Microk8s only"

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -43,6 +43,8 @@ spec:
               secretKeyRef:
                 name: release-name-mongodb-secret
                 key: root-password
+          - name: GLIBC_TUNABLES
+            value: glibc.pthread.rseq=1
 
         volumeMounts:
         - name: data


### PR DESCRIPTION
# Description

Prevent MongoDB 8.x SIGSEGV on Linux kernel >= 6.19 by defaulting `GLIBC_TUNABLES=glibc.pthread.rseq=1` on the mongo container

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

manual, integration

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings