### PR TITLE
fix: semgrep issues

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -4,3 +4,5 @@ ui_tests/
 integration_tests/
 examples/
 charts/splunk-connect-for-snmp/templates/
+# Rendered Redis Secret manifest for the redis_ha test case.
+rendered/manifests/**/redis-secret.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 - Preserve unresolved trap varbind fields during custom translation processing, preventing processing failures and errors.
-
+- Harden the security context for kubernetes templates
 
 ## [1.17.0]
 

--- a/charts/splunk-connect-for-snmp/templates/discovery/job.yaml
+++ b/charts/splunk-connect-for-snmp/templates/discovery/job.yaml
@@ -22,8 +22,19 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: {{ .Chart.Name }}-discovery
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/charts/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -21,8 +21,19 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: {{ .Chart.Name }}-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-ha-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-ha-statefulset.yaml
@@ -42,7 +42,10 @@ spec:
         - name: data
           mountPath: /data/db
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       {{- end }}
 
       {{- if .Values.mongodb.auth.enabled }}
@@ -55,7 +58,10 @@ spec:
         - name: keyfile
           mountPath: /keyfile
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       {{- end }}
 
       containers:

--- a/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -40,7 +40,10 @@ spec:
         - name: {{ $pvcName }}
           mountPath: /data/db
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       {{- end }}
 
       containers:

--- a/charts/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
@@ -26,6 +26,7 @@ spec:
       {{- with .Values.redis.podSecurityContext }}
       securityContext:
         runAsUser: {{ .runAsUser }}
+        runAsNonRoot: true
         fsGroup: {{ .fsGroup }}
       {{- end }}
       {{- if .Values.redis.storage.enabled }}
@@ -45,10 +46,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       {{- end }}
       containers:
       - name: redis
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         ports:
@@ -108,6 +119,8 @@ spec:
         {{- end }}
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {{- toYaml .Values.redis.resources | nindent 10 }}
         {{- if .Values.redis.livenessProbe.enabled | default true }}
@@ -148,6 +161,8 @@ spec:
       - name: redis-config
         configMap:
           name: {{ .Release.Name }}-redis-config
+      - name: tmp
+        emptyDir: {}
       {{- if not .Values.redis.storage.enabled }}
       - name: redis-data
         emptyDir: {}

--- a/charts/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       {{- with .Values.redis.podSecurityContext }}
       securityContext:
         runAsUser: {{ .runAsUser }}
+        runAsNonRoot: true
         fsGroup: {{ .fsGroup }}
       {{- end }}
       initContainers:
@@ -53,9 +54,19 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         ports:
@@ -94,6 +105,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {{- toYaml .Values.redis.resources | nindent 10 }}
         {{- if .Values.redis.livenessProbe.enabled | default true }}
@@ -135,12 +148,16 @@ spec:
       - name: redis-config
         configMap:
           name: {{ .Release.Name }}-redis-config
+      - name: tmp
+        emptyDir: {}
       {{- else if .Values.redis.storage.enabled }}
       # Storage enabled but no existing PVC - use volumeClaimTemplates below
       volumes:
       - name: redis-config
         configMap:
           name: {{ .Release.Name }}-redis-config
+      - name: tmp
+        emptyDir: {}
       {{- else }}
       # Storage disabled - use emptyDir (ephemeral)
       volumes:
@@ -149,6 +166,8 @@ spec:
       - name: redis-config
         configMap:
           name: {{ .Release.Name }}-redis-config
+      - name: tmp
+        emptyDir: {}
       {{- end }}
   {{- if and .Values.redis.storage.enabled (not $existingPVC) }}
   # No existing PVC found, create new one via volumeClaimTemplates

--- a/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+++ b/charts/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
@@ -20,8 +20,19 @@ spec:
       annotations:
         {{- include "splunk-connect-for-snmp.redis-annotations" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: {{ .Values.redis.podSecurityContext.runAsUser }}
+        runAsNonRoot: true
+        fsGroup: {{ .Values.redis.podSecurityContext.fsGroup }}
       containers:
       - name: sentinel
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         ports:

--- a/charts/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/charts/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/charts/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -15,6 +15,7 @@ spec:
       command: ['wget']
       args: ['{{ include "splunk-connect-for-snmp.traps.fullname" . }}:{{ .Values.traps.service.port }}']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/charts/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
@@ -19,6 +19,8 @@ spec:
     spec:
       containers:
       - name: ui-backend-worker
+        securityContext:
+          allowPrivilegeEscalation: false
         image: {{ include "splunk-connect-for-snmp.uiBackImage" . | quote }}
         imagePullPolicy: {{ .Values.UI.backEnd.pullPolicy }}
         command: ["sh","-c","/celery_start.sh"]

--- a/charts/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
@@ -20,6 +20,7 @@ spec:
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
+        runAsNonRoot: true
         fsGroup: 10000
       {{- if .Values.UI.valuesFileDirectory }}
       initContainers:
@@ -34,13 +35,18 @@ spec:
                     setfacl -n -Rm d:m::rwx,m::rwx,d:g:10000:rwx,g:10000:rwx {{ include "splunk-connect-for-snmp-ui.hostMountPath" . }};
                 fi;' ]
           securityContext:
+            # nosemgrep: splunk.run-as-non-root
             runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
           volumeMounts:
           - name: values-directory
             mountPath: {{ include "splunk-connect-for-snmp-ui.hostMountPath" . }}
       {{- end }}
       containers:
       - name: ui-backend
+        securityContext:
+          allowPrivilegeEscalation: false
         image: {{ include "splunk-connect-for-snmp.uiBackImage" . | quote }}
         imagePullPolicy: {{ .Values.UI.backEnd.pullPolicy }}
         command: ["sh","-c","/flask_start.sh"]

--- a/charts/splunk-connect-for-snmp/templates/ui/deployment-frontend.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/deployment-frontend.yaml
@@ -17,6 +17,8 @@ spec:
     spec:
       containers:
       - name: ui-frontend
+        securityContext:
+          allowPrivilegeEscalation: false
         image: {{ include "splunk-connect-for-snmp.uiFrontImage" . | quote }}
         imagePullPolicy: {{ .Values.UI.frontEnd.pullPolicy }}
         env:

--- a/charts/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
@@ -13,7 +13,10 @@ spec:
     image: {{ .Values.UI.init.repository }}
     imagePullPolicy: {{ .Values.UI.init.pullPolicy }}
     securityContext:
+      # nosemgrep: splunk.run-as-non-root
       runAsUser: 0
+      runAsNonRoot: false
+      allowPrivilegeEscalation: false
     command: ['sh', '-c', '
     setfacl --recursive --remove-all {{ include "splunk-connect-for-snmp-ui.hostMountPath" . }};
     ']

--- a/charts/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
@@ -13,8 +13,8 @@ spec:
     image: {{ .Values.UI.init.repository }}
     imagePullPolicy: {{ .Values.UI.init.pullPolicy }}
     securityContext:
-      # nosemgrep: splunk.run-as-non-root-unsafe-value
       runAsUser: 0
+      # nosemgrep: splunk.run-as-non-root-unsafe-value
       runAsNonRoot: false
       allowPrivilegeEscalation: false
     command: ['sh', '-c', '

--- a/charts/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
+++ b/charts/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
@@ -13,7 +13,7 @@ spec:
     image: {{ .Values.UI.init.repository }}
     imagePullPolicy: {{ .Values.UI.init.pullPolicy }}
     securityContext:
-      # nosemgrep: splunk.run-as-non-root
+      # nosemgrep: splunk.run-as-non-root-unsafe-value
       runAsUser: 0
       runAsNonRoot: false
       allowPrivilegeEscalation: false

--- a/charts/splunk-connect-for-snmp/templates/worker/discovery/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/discovery/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-discovery
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/charts/splunk-connect-for-snmp/templates/worker/flower/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/flower/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-flower
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/charts/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -35,6 +35,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/charts/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/charts/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/charts/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -35,6 +35,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -623,6 +623,13 @@ mongodb:
     tag: "8.3.4"
     pullPolicy: IfNotPresent
 
+  # Container-level security context for the mongod container. runAsNonRoot/
+  # readOnlyRootFilesystem are intentionally not set here: the upstream mongo
+  # image's entrypoint needs root to take ownership of the data volume on
+  # first start (see initPermissions below for an alternative).
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+
   auth:
     enabled: true
     rootUser: admin

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/discovery/job.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/discovery/job.yaml
@@ -4,6 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: release-name-splunk-connect-for-snmp-discovery
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp
     app.kubernetes.io/component: discovery
@@ -22,8 +23,19 @@ spec:
         app.kubernetes.io/component: discovery
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-discovery
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/discovery/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/discovery/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-splunk-connect-for-snmp-worker-discovery
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-connect-for-snmp
     app.kubernetes.io/component: worker-discovery
@@ -20,6 +21,8 @@ spec:
       app.kubernetes.io/instance: release-name
   template:
     metadata:
+      annotations:
+        checksum/redis-config: e82c09fa615350d9c147a0884485f953308babd6b8842d0cbe695ed5595eb530
       labels:
         app.kubernetes.io/name: splunk-connect-for-snmp
         app.kubernetes.io/component: worker-discovery
@@ -31,6 +34,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-discovery
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_autoscaling_enabled_deprecated/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend-worker.yaml
@@ -20,6 +20,8 @@ spec:
     spec:
       containers:
       - name: ui-backend-worker
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "ghcr.io/splunk/sc4snmp-ui/backend/container:main"
         imagePullPolicy: Always
         command: ["sh","-c","/celery_start.sh"]

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-backend.yaml
@@ -21,6 +21,7 @@ spec:
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
+        runAsNonRoot: true
         fsGroup: 10000
       initContainers:
         - name: patch-log-dirs
@@ -34,12 +35,17 @@ spec:
                     setfacl -n -Rm d:m::rwx,m::rwx,d:g:10000:rwx,g:10000:rwx /var/values_dir;
                 fi;' ]
           securityContext:
+            # nosemgrep: splunk.run-as-non-root
             runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
           volumeMounts:
           - name: values-directory
             mountPath: /var/values_dir
       containers:
       - name: ui-backend
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "ghcr.io/splunk/sc4snmp-ui/backend/container:main"
         imagePullPolicy: Always
         command: ["sh","-c","/flask_start.sh"]

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-frontend.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/deployment-frontend.yaml
@@ -18,6 +18,8 @@ spec:
     spec:
       containers:
       - name: ui-frontend
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "ghcr.io/splunk/sc4snmp-ui/frontend/container:main"
         imagePullPolicy: Always
         env:

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
@@ -14,8 +14,8 @@ spec:
     image: registry.access.redhat.com/ubi9/ubi
     imagePullPolicy: IfNotPresent
     securityContext:
-      # nosemgrep: splunk.run-as-non-root-unsafe-value
       runAsUser: 0
+      # nosemgrep: splunk.run-as-non-root-unsafe-value
       runAsNonRoot: false
       allowPrivilegeEscalation: false
     command: ['sh', '-c', '

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
@@ -14,7 +14,10 @@ spec:
     image: registry.access.redhat.com/ubi9/ubi
     imagePullPolicy: IfNotPresent
     securityContext:
+      # nosemgrep: splunk.run-as-non-root
       runAsUser: 0
+      runAsNonRoot: false
+      allowPrivilegeEscalation: false
     command: ['sh', '-c', '
     setfacl --recursive --remove-all /var/values_dir;
     ']

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/ui/revert-patch-log-dirs.yaml
@@ -14,7 +14,7 @@ spec:
     image: registry.access.redhat.com/ubi9/ubi
     imagePullPolicy: IfNotPresent
     securityContext:
-      # nosemgrep: splunk.run-as-non-root
+      # nosemgrep: splunk.run-as-non-root-unsafe-value
       runAsUser: 0
       runAsNonRoot: false
       allowPrivilegeEscalation: false

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_enable_ui/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_metallb_false/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -28,6 +28,8 @@ spec:
       - name: mongodb
         image: "bitnamilegacy/mongodb:8.0.13-debian-10-r0"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_custom_image/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_mongodb_ha/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_polling/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_only_traps/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_probes_enabled/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -24,8 +24,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/redis-ha-statefulset.yaml
@@ -27,10 +27,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -44,10 +45,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -94,6 +105,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -122,6 +135,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: redis-data

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/redis/sentinel/redis-sentinel-statefulset.yaml
@@ -22,9 +22,20 @@ spec:
         checksum/redis-config: 52233e7984ec9733ee5d72c255220b5f26923d0723b6a2dd9d645205d3bf81d5
         checksum/redis-secret: 908cbead70ef3a415f7509bf2922a7eb195dd8dc27ba5735ecde8c7794bb4b74
     spec:
+      securityContext:
+        runAsUser: 999
+        runAsNonRoot: true
+        fsGroup: 999
       containers:
       - name: sentinel
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26379

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_redis_ha/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_token_as_a_secret/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/inventory/job.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/inventory/job.yaml
@@ -22,8 +22,19 @@ spec:
         app.kubernetes.io/component: inventory
         app.kubernetes.io/instance: release-name
     spec:
+      securityContext:
+        fsGroup: 10001
       containers:
         - name: splunk-connect-for-snmp-inventory
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           image: "ghcr.io/splunk/splunk-connect-for-snmp/container:CURRENT-VERSION"
           imagePullPolicy: Always
           args:

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/scheduler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-scheduler
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/worker/poller/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-poller
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_token_from_vault/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -26,8 +26,10 @@ spec:
 
       containers:
       - name: mongodb
-        image: "mongo:8.2.7"
+        image: "mongo:8.3.4"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/mongodb/mongodb-standalone-statefulset.yaml
@@ -21,6 +21,12 @@ spec:
         app: release-name-mongodb
         mode: standalone
     spec:
+      securityContext:
+        enabled: true
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
 
       initContainers:
 
@@ -30,6 +36,18 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: {}
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - containerPort: 27017

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/redis/redis-standalone-statefulset.yaml
@@ -28,10 +28,11 @@ spec:
     spec:
       securityContext:
         runAsUser: 999
+        runAsNonRoot: true
         fsGroup: 999
       initContainers:
       - name: fix-permissions
-        image: redis:8.6.2
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         command:
         - sh
@@ -52,10 +53,20 @@ spec:
         - name: redis-data
           mountPath: /data
         securityContext:
+          # nosemgrep: splunk.run-as-non-root
           runAsUser: 0  # Must run as root to chown
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
       containers:
       - name: redis
-        image: redis:8.6.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: redis:8.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379
@@ -75,6 +86,8 @@ spec:
           mountPath: /data
         - name: redis-config
           mountPath: /etc/redis
+        - name: tmp
+          mountPath: /tmp
         resources:
           {}
         livenessProbe:
@@ -100,6 +113,8 @@ spec:
       - name: redis-config
         configMap:
           name: release-name-redis-config
+      - name: tmp
+        emptyDir: {}
   # No existing PVC found, create new one via volumeClaimTemplates
   volumeClaimTemplates:
   - metadata:

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/tests/test-connection.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/tests/test-connection.yaml
@@ -19,6 +19,7 @@ spec:
       command: ['wget']
       args: ['release-name-splunk-connect-for-snmp-trap:162']
       securityContext:
+        allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/traps/deployment.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/traps/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-traps
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/sender/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-sender
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
+++ b/rendered/manifests/tests_traps_nodeport/splunk-connect-for-snmp/templates/worker/trap/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
         - name: splunk-connect-for-snmp-worker-trap
           securityContext:
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
# Description

  Fixes all 206 Semgrep Kubernetes hardening findings (splunk.* rules) flagged against the Helm chart's rendered manifests.

  - Main app containers (scheduler, traps, worker/*, test-connection): add missing allowPrivilegeEscalation: false.
  - Discovery/inventory Jobs: add full pod + container securityContext hardening, matching the existing worker containers' UID/pattern.
  - Redis (standalone, HA, sentinel): add container-level hardening (readOnlyRootFilesystem, runAsNonRoot, capability drop) plus a writable /tmp emptyDir for the config copy at startup.
  - MongoDB & UI app containers: add allowPrivilegeEscalation: false only. runAsNonRoot/readOnlyRootFilesystem intentionally left as documented exceptions — these run external images whose write paths/default UID can't be verified from this
  repo.
  - Root-required init/hook containers (mongodb init-permissions/keyfile-setup, redis fix-permissions, UI patch-log-dirs/revert-patch-log-dirs): inline # nosemgrep: splunk.run-as-non-root annotations, since these legitimately need UID 0 for
  chown/setfacl.
  - .semgrepignore: exclude the one rendered Redis Secret manifest (redis-secret.yaml) flagged for secrets-in-config-file — it's a throwaway test-fixture password (rendered/values_redis_ha.yaml), not a shipped secret.
  - Regenerated all rendered/manifests/ fixtures via make render.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Dependency update
- [ ] Bug fix
- [ ] New feature
- [x] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings