### PR TITLE
fix: running schedules when reinstalling from mongo pvc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Changed
 
 ### Fixed
-- Preserve unresolved trap varbind fields during custom translation processing, preventing processing failures and errors.
+- Preserve unresolved trap varbind fields during custom translation processing, preventing processing failures and errors
 - Harden the security context for kubernetes templates
+- Fix schedules not resuming for unchanged inventory records after Redis/RedBeat is reset while MongoDB data is preserved
 
 ## [1.17.0]
 

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -22,14 +22,14 @@ UI:
   enable: false
   frontEnd:
     NodePort: 30001
+    repository: ghcr.io/splunk/sc4snmp-ui/frontend/container
+    tag: "1.2.3-beta.2"
     pullPolicy: "Always"
-    repository: ajasnosz558/ui-frontend
-    tag: "new3"
   backEnd:
     NodePort: 30002
+    repository: ghcr.io/splunk/sc4snmp-ui/backend/container
+    tag: "1.2.3-beta.2"
     pullPolicy: "Always"
-    repository: ajasnosz558/ui-backend
-    tag: "new3"
   # Base container that sets permissions for folders mounted to UI containers
   init:
     repository: registry.access.redhat.com/ubi9/ubi

--- a/charts/splunk-connect-for-snmp/values.yaml
+++ b/charts/splunk-connect-for-snmp/values.yaml
@@ -22,14 +22,14 @@ UI:
   enable: false
   frontEnd:
     NodePort: 30001
-    repository: ghcr.io/splunk/sc4snmp-ui/frontend/container
-    tag: "1.2.1"
     pullPolicy: "Always"
+    repository: ajasnosz558/ui-frontend
+    tag: "new3"
   backEnd:
     NodePort: 30002
-    repository: ghcr.io/splunk/sc4snmp-ui/backend/container
-    tag: "1.2.1"
     pullPolicy: "Always"
+    repository: ajasnosz558/ui-backend
+    tag: "new3"
   # Base container that sets permissions for folders mounted to UI containers
   init:
     repository: registry.access.redhat.com/ubi9/ubi

--- a/integration_tests/tests/test_poller_integration.py
+++ b/integration_tests/tests/test_poller_integration.py
@@ -21,6 +21,8 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString as dq
 from ruamel.yaml.scalarstring import SingleQuotedScalarString as sq
 
 from integration_tests.utils.splunk_test_utils import (
+    rebuild_stack_preserve_mongo_compose,
+    rebuild_stack_preserve_mongo_microk8s,
     splunk_single_search,
     update_file_microk8s,
     update_groups_compose,
@@ -1942,3 +1944,85 @@ def run_retried_single_search(setup_splunk, search_string, retries, wait=20):
         logger.info(f"Attempt {attempt+1}/{retries}: no results. Waiting {wait}s...")
         time.sleep(wait)
     return 0, 0
+
+
+@pytest.fixture(scope="class")
+def setup_rebuild(request):
+    trap_external_ip = request.config.getoption("trap_external_ip")
+    deployment = request.config.getoption("sc4snmp_deployment")
+    profile = {
+        "rebuild_profile": {
+            "frequency": 5,
+            "varBinds": [yaml_escape_list(sq("TCP-MIB"))],
+        }
+    }
+
+    if str(deployment) == "microk8s":
+        update_profiles_microk8s(profile)
+        update_file_microk8s(
+            [f"{trap_external_ip},,2c,public,,,600,rebuild_profile,,"], "inventory.yaml"
+        )
+        upgrade_helm_microk8s(["inventory.yaml", "profiles.yaml"])
+    else:
+        update_profiles_compose(profile)
+        update_inventory_compose(
+            [f"{trap_external_ip},,2c,public,,,600,rebuild_profile,,"]
+        )
+        upgrade_docker_compose()
+    time.sleep(30)
+    yield
+    if str(deployment) == "microk8s":
+        upgrade_helm_microk8s(
+            [f"{trap_external_ip},,2c,public,,,600,rebuild_profile,,t"]
+        )
+    else:
+        update_inventory_compose(
+            [f"{trap_external_ip},,2c,public,,,600,rebuild_profile,,t"]
+        )
+        upgrade_docker_compose()
+    time.sleep(20)
+
+
+@pytest.mark.usefixtures("setup_rebuild")
+@pytest.mark.part6
+class TestRebuildWithoutConfigChange:
+    """
+    Reproduces the reported scenario: the environment is rebuilt from scratch (all pods /
+    containers deleted, Redis wiped) while the MongoDB volume/PVC survives untouched, and no
+    inventory/profile/group config is changed. Polling must resume on its own, without any
+    edit made through the UI.
+    """
+
+    def test_polling_resumes_after_rebuild_without_config_change(
+        self, request, setup_splunk
+    ):
+        search_string = """| mpreview index=netmetrics | search profiles=rebuild_profile
+        | search "TCP-MIB" """
+
+        # Sanity check: metrics are flowing for the profile before the rebuild.
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, search_string, 2
+        )
+        assert result_count > 0
+        assert metric_count > 0
+
+        deployment = request.config.getoption("sc4snmp_deployment")
+        logger.info(
+            "Simulating a rebuild that wipes Redis/RedBeat but preserves the Mongo "
+            "volume, with no inventory/profile/group config change"
+        )
+        if str(deployment) == "microk8s":
+            rebuild_stack_preserve_mongo_microk8s()
+        else:
+            rebuild_stack_preserve_mongo_compose()
+        time.sleep(60)
+
+        # Metrics must resume for the same profile with a recent time window, even though
+        # nothing was changed in the UI/config after the rebuild.
+        recent_search_string = """| mpreview index=netmetrics earliest=-3m | search profiles=rebuild_profile
+        | search "TCP-MIB" """
+        result_count, metric_count = run_retried_single_search(
+            setup_splunk, recent_search_string, 5, wait=30
+        )
+        assert result_count > 0
+        assert metric_count > 0

--- a/integration_tests/utils/splunk_test_utils.py
+++ b/integration_tests/utils/splunk_test_utils.py
@@ -503,7 +503,9 @@ def rebuild_stack_preserve_mongo_microk8s():
             "Deleting Redis/scheduler/worker resources to simulate a rebuild "
             "that drops RedBeat's schedule, while keeping the Mongo PVC"
         )
-        os.system("sudo microk8s kubectl delete statefulset snmp-redis-standalone -n sc4snmp")
+        os.system(
+            "sudo microk8s kubectl delete statefulset snmp-redis-standalone -n sc4snmp"
+        )
         os.system(
             "sudo microk8s kubectl delete deployment "
             "snmp-splunk-connect-for-snmp-scheduler "

--- a/integration_tests/utils/splunk_test_utils.py
+++ b/integration_tests/utils/splunk_test_utils.py
@@ -357,6 +357,29 @@ def upgrade_docker_compose():
     )
 
 
+def rebuild_stack_preserve_mongo_compose():
+    """
+    Simulate rebuilding the environment from scratch while keeping the MongoDB data
+    volume: wipe Redis (RedBeat's schedule store) and recreate the poller/scheduler/worker
+    containers, but leave the `mongo` container/volume untouched. Then re-run the inventory
+    container the same way a normal redeploy does, WITHOUT changing any config file, so the
+    inventory records end up "Unchanged" from Mongo's point of view.
+    """
+    compose_dir = BASE_DIR / "docker_compose"
+    logger.info("Wiping Redis to simulate a rebuild that drops RedBeat's schedule")
+    os.system("sudo docker exec redis redis-cli FLUSHALL")
+    os.system(
+        f"sudo docker compose -f {compose_dir}/docker-compose.yaml "
+        f"--env-file {compose_dir}/.env up -d --force-recreate "
+        f"redis scheduler worker-poller worker-sender worker-trap"
+    )
+    logger.info("Re-running inventory container without any config change")
+    os.system(
+        f"sudo docker compose -f {compose_dir}/docker-compose.yaml "
+        f"--env-file {compose_dir}/.env up -d --force-recreate inventory"
+    )
+
+
 def create_v3_secrets_compose():
     upgrade_env_compose("ENABLE_TRAPS_SECRETS", "true")
     upgrade_env_compose(
@@ -464,6 +487,42 @@ def upgrade_helm_microk8s(yaml_files):
 
     except Exception as e:
         logger.info(f"[ERROR] Helm upgrade failed: {e}")
+        raise
+
+
+def rebuild_stack_preserve_mongo_microk8s():
+    """
+    Simulate rebuilding the environment from scratch while keeping the MongoDB PVC: delete
+    the Redis StatefulSet (RedBeat's schedule store) and the scheduler/worker Deployments,
+    but never touch the `snmp-mongodb` StatefulSet or its PVC. `helm upgrade` recreates the
+    deleted resources on re-apply. Finally re-run the inventory Job WITHOUT changing any
+    `-f` values file, so the inventory records end up "Unchanged" from Mongo's point of view.
+    """
+    try:
+        logger.info(
+            "Deleting Redis/scheduler/worker resources to simulate a rebuild "
+            "that drops RedBeat's schedule, while keeping the Mongo PVC"
+        )
+        os.system("sudo microk8s kubectl delete statefulset snmp-redis-standalone -n sc4snmp")
+        os.system(
+            "sudo microk8s kubectl delete deployment "
+            "snmp-splunk-connect-for-snmp-scheduler "
+            "snmp-splunk-connect-for-snmp-worker-poller "
+            "snmp-splunk-connect-for-snmp-worker-sender "
+            "snmp-splunk-connect-for-snmp-worker-trap "
+            "-n sc4snmp --ignore-not-found"
+        )
+        os.system(
+            "sudo microk8s kubectl delete jobs/snmp-splunk-connect-for-snmp-inventory -n sc4snmp"
+        )
+        logger.info("Re-installing the release without any config change")
+        os.system(
+            "sudo microk8s helm3 upgrade --install snmp -f values.yaml "
+            "./../charts/splunk-connect-for-snmp --namespace=sc4snmp --create-namespace"
+        )
+
+    except Exception as e:
+        logger.info(f"[ERROR] Rebuild simulation failed: {e}")
         raise
 
 

--- a/splunk_connect_for_snmp/common/inventory_processor.py
+++ b/splunk_connect_for_snmp/common/inventory_processor.py
@@ -221,9 +221,17 @@ class InventoryRecordManager:
             logger.info(f"Modified Record {inventory_record}")
         else:
             logger.info(f"Unchanged Record {inventory_record}")
+            target = transform_address_to_key(
+                inventory_record.address, inventory_record.port
+            )
             if expiry_time_changed:
                 logger.info(
                     f"Task expiry time was modified, generating new tasks for record {inventory_record}"
+                )
+            elif not self.periodic_object_collection.walk_task_exists(target):
+                logger.info(
+                    f"Walk task for {target} is missing from the scheduler "
+                    f"(e.g. Redis/RedBeat was reset); re-registering it"
                 )
             else:
                 return

--- a/splunk_connect_for_snmp/customtaskmanager.py
+++ b/splunk_connect_for_snmp/customtaskmanager.py
@@ -132,3 +132,11 @@ class CustomPeriodicTaskManager:
             return periodic_tasks[0].options.get("expires", None)
         else:
             return None
+
+    def walk_task_exists(self, target: str) -> bool:
+        walk_task_name = f"sc4snmp;{target};walk"
+        try:
+            RedBeatSchedulerEntry.from_key(f"redbeat:{walk_task_name}", app=app)
+            return True
+        except KeyError:
+            return False

--- a/test/inventory/test_loader.py
+++ b/test/inventory/test_loader.py
@@ -403,11 +403,68 @@ class TestLoader(TestCase):
         periodic_obj_mock = Mock()
         m_taskManager.return_value = periodic_obj_mock
         periodic_obj_mock.did_expiry_time_change.return_value = False
+        periodic_obj_mock.walk_task_exists.return_value = True
         m_migrate.return_value = False
         m_load_profiles.return_value = default_profiles
         self.assertFalse(load())
 
         periodic_obj_mock.manage_task.assert_not_called()
+
+    @mock.patch(
+        "splunk_connect_for_snmp.common.inventory_processor.CONFIG_FROM_MONGO", False
+    )
+    @mock.patch(
+        "splunk_connect_for_snmp.common.collection_manager.CONFIG_FROM_MONGO", False
+    )
+    @mock.patch("splunk_connect_for_snmp.inventory.loader.CONFIG_FROM_MONGO", False)
+    @mock.patch(
+        "splunk_connect_for_snmp.inventory.loader.CHAIN_OF_TASKS_EXPIRY_TIME", 180
+    )
+    @patch("splunk_connect_for_snmp.common.inventory_processor.gen_walk_task")
+    @patch("builtins.open", new_callable=mock_open, read_data=mock_inventory)
+    @patch("splunk_connect_for_snmp.customtaskmanager.CustomPeriodicTaskManager")
+    @mock.patch("pymongo.collection.Collection.update_one")
+    @patch("splunk_connect_for_snmp.inventory.loader.migrate_database")
+    @mock.patch(
+        "splunk_connect_for_snmp.common.collection_manager.ProfilesManager.update_all"
+    )
+    @mock.patch(
+        "splunk_connect_for_snmp.common.collection_manager.ProfilesManager.return_collection"
+    )
+    @mock.patch(
+        "splunk_connect_for_snmp.common.collection_manager.GroupsManager.update_all"
+    )
+    @mock.patch(
+        "splunk_connect_for_snmp.common.collection_manager.GroupsManager.return_collection"
+    )
+    @mock.patch("splunk_connect_for_snmp.inventory.loader.configure_ui_database")
+    def test_load_unchanged_record_missing_walk_task(
+        self,
+        m_configure_ui_database,
+        m_load_groups,
+        m_update_groups,
+        m_load_profiles,
+        m_update_profiles,
+        m_migrate,
+        m_mongo_collection,
+        m_taskManager,
+        m_open,
+        m_gen_walk_task,
+    ):
+        # Reproduces the rebuild-without-config-change scenario: MongoDB survives so the
+        # record is "Unchanged", but RedBeat/Redis was wiped so the walk task is missing.
+        m_mongo_collection.return_value = UpdateResult(
+            {"n": 1, "nModified": 0, "upserted": None}, True
+        )
+        m_gen_walk_task.return_value = expected_managed_task
+        periodic_obj_mock = Mock()
+        m_taskManager.return_value = periodic_obj_mock
+        periodic_obj_mock.did_expiry_time_change.return_value = False
+        periodic_obj_mock.walk_task_exists.return_value = False
+        m_load_profiles.return_value = default_profiles
+        self.assertFalse(load())
+
+        periodic_obj_mock.manage_task.assert_called_with(**expected_managed_task)
 
     @mock.patch(
         "splunk_connect_for_snmp.common.inventory_processor.CONFIG_FROM_MONGO", False

--- a/test/other/test_custom_task_manager.py
+++ b/test/other/test_custom_task_manager.py
@@ -297,6 +297,28 @@ class TestCustomTaskManager(TestCase):
         task_manager.delete_all_walk_tasks.assert_not_called()
         self.assertFalse(did_time_change)
 
+    @patch("redbeat.schedulers.RedBeatSchedulerEntry.from_key")
+    def test_walk_task_exists_true(self, redbeat_scheduler_entry_from_key):
+        task_manager = CustomPeriodicTaskManager.__new__(CustomPeriodicTaskManager)
+
+        redbeat_scheduler_entry_from_key.return_value = Mock()
+
+        self.assertTrue(task_manager.walk_task_exists("192.168.0.1:161"))
+        redbeat_scheduler_entry_from_key.assert_called_with(
+            "redbeat:sc4snmp;192.168.0.1:161;walk", app=ANY
+        )
+
+    @patch("redbeat.schedulers.RedBeatSchedulerEntry.from_key")
+    def test_walk_task_exists_false(self, redbeat_scheduler_entry_from_key):
+        task_manager = CustomPeriodicTaskManager.__new__(CustomPeriodicTaskManager)
+
+        redbeat_scheduler_entry_from_key.side_effect = KeyError
+
+        self.assertFalse(task_manager.walk_task_exists("192.168.0.1:161"))
+        redbeat_scheduler_entry_from_key.assert_called_with(
+            "redbeat:sc4snmp;192.168.0.1:161;walk", app=ANY
+        )
+
     @patch("redbeat.schedulers.RedBeatSchedulerEntry.get_schedules")
     @patch("redbeat.schedulers.RedBeatSchedulerEntry.from_key")
     def test_rerun_all_walks(self, m_from_key, m_objects):

--- a/ui_tests/config/ui_values.yaml
+++ b/ui_tests/config/ui_values.yaml
@@ -2,14 +2,14 @@ UI:
   enable: true
   frontEnd:
     NodePort: 30001
-    repository: ghcr.io/splunk/sc4snmp-ui/frontend/container
-    tag: "1.2.2"
     pullPolicy: "Always"
+    repository: ajasnosz558/ui-frontend
+    tag: "new3"
   backEnd:
     NodePort: 30002
-    repository: ghcr.io/splunk/sc4snmp-ui/backend/container
-    tag: "1.2.2"
     pullPolicy: "Always"
+    repository: ajasnosz558/ui-backend
+    tag: "new3"
   init:
     image: registry.access.redhat.com/ubi9/ubi
     pullPolicy: IfNotPresent

--- a/ui_tests/config/ui_values.yaml
+++ b/ui_tests/config/ui_values.yaml
@@ -2,14 +2,14 @@ UI:
   enable: true
   frontEnd:
     NodePort: 30001
+    repository: ghcr.io/splunk/sc4snmp-ui/frontend/container
+    tag: "1.2.3-beta.2"
     pullPolicy: "Always"
-    repository: ajasnosz558/ui-frontend
-    tag: "new3"
   backEnd:
     NodePort: 30002
+    repository: ghcr.io/splunk/sc4snmp-ui/backend/container
+    tag: "1.2.3-beta.2"
     pullPolicy: "Always"
-    repository: ajasnosz558/ui-backend
-    tag: "new3"
   init:
     image: registry.access.redhat.com/ubi9/ubi
     pullPolicy: IfNotPresent


### PR DESCRIPTION
# Description

Re-register walk tasks for unchanged inventory records when RedBeat/Redis is reset but MongoDB is preserved (e.g. on reinstall), preventing polling from silently stopping.
UI changes: https://github.com/splunk/SC4SNMP-UI/pull/122

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

manual, ui, integration

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings