### PR TITLE
fix: prevent duplicate profiles when merging varbind mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Preserve unresolved trap varbind fields during custom translation processing, preventing processing failures and errors
 - Harden the security context for kubernetes templates
 - Fix schedules not resuming for unchanged inventory records after Redis/RedBeat is reset while MongoDB data is preserved
+- Prevent duplicate profiles when merging varbind mappings to avoid mappings growing unnecessarily large
 
 ## [1.17.0]
 

--- a/splunk_connect_for_snmp/snmp/auth.py
+++ b/splunk_connect_for_snmp/snmp/auth.py
@@ -163,7 +163,12 @@ def get_auth_v3(logger, rt: RecordType, snmp_engine: SnmpEngine) -> UsmUserData:
 
         security_name = None
         logger.debug(
-            f"{username},authKey={auth_key},privKey={priv_key},authProtocol={auth_protocol},privProtocol={priv_protocol},securityEngineId={security_engine_id},securityName={security_name},authKeyType={auth_key_type},privKeyType={priv_key_type}"
+            f"{username},"
+            f"authKey={'*' * len(auth_key) if auth_key is not None else None},"
+            f"privKey={'*' * len(priv_key) if priv_key is not None else None},"
+            f"authProtocol={auth_protocol},privProtocol={priv_protocol},"
+            f"securityEngineId={security_engine_id},securityName={security_name},"
+            f"authKeyType={auth_key_type},privKeyType={priv_key_type}"
         )
         return UsmUserData(
             username,

--- a/splunk_connect_for_snmp/snmp/varbinds_resolver.py
+++ b/splunk_connect_for_snmp/snmp/varbinds_resolver.py
@@ -221,19 +221,61 @@ class Profile:
 
     def add_mappings(self, dict1, dict2) -> dict:
         """
-        Helper to adding varbinds mapping dictionaries inside profiles.
-        When there are the same keys in both dictionaries they will be added after comma.
-        :param dict1:
-        :param dict2:
-        :return mapping:
+        Merge two OID-to-profile mappings without modifying either input.
+
+        Each dictionary maps an OID to one or more comma-separated profile
+        names. When an OID exists in both dictionaries, each distinct profile
+        name is retained once, in first-seen order.
+
+        The previous logic compared the full comma-separated profile string,
+        so duplicate profiles could be added when the profile order differed.
+
+        :param dict1: Base OID-to-profile mapping.
+        :param dict2: OID-to-profile mapping to merge into the base mapping.
+        :return: A new merged mapping containing distinct profile names.
         """
-        mapping = dict1
-        for k, v in dict2.items():
-            if mapping.get(k) and v not in mapping.get(k):
-                mapping[k] = f"{mapping[k]},{v}"
-            elif not mapping.get(k):
-                mapping[k] = v
+        mapping = {
+            mapping_key: ",".join(self.unique_profile_names(profile_names))
+            for mapping_key, profile_names in dict1.items()
+        }
+
+        for mapping_key, profile_names in dict2.items():
+            dict1_profiles = self.unique_profile_names(mapping.get(mapping_key, ""))
+            dict2_profiles = self.unique_profile_names(profile_names)
+
+            dict1_profile_set = set(dict1_profiles)
+            added_profiles = [
+                profile_name
+                for profile_name in dict2_profiles
+                if profile_name not in dict1_profile_set
+            ]
+            result_profiles = dict1_profiles + added_profiles
+            mapping[mapping_key] = ",".join(result_profiles)
+
+            logger.debug(
+                f"Profile.add_mappings name={self.name} key={mapping_key} "
+                f"dict1_profiles={dict1_profiles} "
+                f"dict2_profiles={dict2_profiles} "
+                f"added_profiles={added_profiles} "
+                f"result_profiles={result_profiles}"
+            )
         return mapping
+
+    @staticmethod
+    def unique_profile_names(profile_value: str) -> list[str]:
+        """
+        Return unique profile names while preserving their original order.
+
+        :param profile_value: Comma-separated profile names.
+        :return: Profile names with empty and duplicate entries removed.
+        """
+        return list(
+            dict.fromkeys(
+                profile_name
+                for profile_name in profile_value.split(",")
+                if profile_name
+            )
+        )
 
 
 class ProfileCollection:

--- a/splunk_connect_for_snmp/snmp/varbinds_resolver.py
+++ b/splunk_connect_for_snmp/snmp/varbinds_resolver.py
@@ -209,17 +209,23 @@ class Profile:
         new_instance.varbinds_bulk = self.varbinds_bulk + other.varbinds_bulk
         new_instance.varbinds_get = self.varbinds_get + other.varbinds_get
         new_instance.varbinds_bulk_mapping = self.add_mappings(
-            self.varbinds_bulk_mapping, other.varbinds_bulk_mapping
+            base_mapping=self.varbinds_bulk_mapping,
+            incoming_mapping=other.varbinds_bulk_mapping,
         )
         new_instance.varbinds_get_mapping = self.add_mappings(
-            self.varbinds_get_mapping, other.varbinds_get_mapping
+            base_mapping=self.varbinds_get_mapping,
+            incoming_mapping=other.varbinds_get_mapping,
         )
         return new_instance
 
     def __repr__(self):
         return f"Profile: {self.name}, varbinds_get: {self.varbinds_get}, varbinds_bulk: {self.varbinds_bulk}, varbinds_get_mapping: {self.varbinds_get_mapping}, varbinds_bulk_mapping: {self.varbinds_bulk_mapping}"
 
-    def add_mappings(self, dict1, dict2) -> dict:
+    def add_mappings(
+        self,
+        base_mapping: dict[str, str],
+        incoming_mapping: dict[str, str],
+    ) -> dict[str, str]:
         """
         Merge two OID-to-profile mappings without modifying either input.
 
@@ -230,36 +236,40 @@ class Profile:
         The previous logic compared the full comma-separated profile string,
         so duplicate profiles could be added when the profile order differed.
 
-        :param dict1: Base OID-to-profile mapping.
-        :param dict2: OID-to-profile mapping to merge into the base mapping.
+        :param base_mapping: Existing OID-to-profile mapping.
+        :param incoming_mapping: OID-to-profile mapping to merge into the base.
         :return: A new merged mapping containing distinct profile names.
         """
-        mapping = {
-            mapping_key: ",".join(self.unique_profile_names(profile_names))
-            for mapping_key, profile_names in dict1.items()
+        merged_profile_names = {
+            mapping_key: Profile.unique_profile_names(profile_value)
+            for mapping_key, profile_value in base_mapping.items()
         }
 
-        for mapping_key, profile_names in dict2.items():
-            dict1_profiles = self.unique_profile_names(mapping.get(mapping_key, ""))
-            dict2_profiles = self.unique_profile_names(profile_names)
+        for mapping_key, profile_value in incoming_mapping.items():
+            base_profiles = merged_profile_names.get(mapping_key, [])
+            incoming_profiles = Profile.unique_profile_names(profile_value)
 
-            dict1_profile_set = set(dict1_profiles)
+            base_profile_set = set(base_profiles)
             added_profiles = [
                 profile_name
-                for profile_name in dict2_profiles
-                if profile_name not in dict1_profile_set
+                for profile_name in incoming_profiles
+                if profile_name not in base_profile_set
             ]
-            result_profiles = dict1_profiles + added_profiles
-            mapping[mapping_key] = ",".join(result_profiles)
+            result_profiles = base_profiles + added_profiles
+            merged_profile_names[mapping_key] = result_profiles
 
             logger.debug(
                 f"Profile.add_mappings name={self.name} key={mapping_key} "
-                f"dict1_profiles={dict1_profiles} "
-                f"dict2_profiles={dict2_profiles} "
+                f"base_profiles={base_profiles} "
+                f"incoming_profiles={incoming_profiles} "
                 f"added_profiles={added_profiles} "
                 f"result_profiles={result_profiles}"
             )
-        return mapping
+
+        return {
+            mapping_key: ",".join(profile_names)
+            for mapping_key, profile_names in merged_profile_names.items()
+        }
 
     @staticmethod
     def unique_profile_names(profile_value: str) -> list[str]:

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import MagicMock, patch
 
 from pysnmp.smi.rfc1902 import ObjectType
 
@@ -343,21 +342,4 @@ class TestProfile(unittest.TestCase):
                 "SNMPv2-MIB::sysDescr": "profile_b",
                 "IF-MIB::ifDescr": "profile_b",
             },
-        )
-
-    @patch("splunk_connect_for_snmp.snmp.varbinds_resolver.logger")
-    def test_add_mappings_logs_duplicate_decision(self, mock_logger):
-        profile = Profile("test", self.profile_dict)
-
-        result = profile.add_mappings(
-            {"SNMPv2-MIB::sysName.0": "profile_a,profile_b"},
-            {"SNMPv2-MIB::sysName.0": "profile_b,profile_a"},
-        )
-
-        self.assertEqual(result["SNMPv2-MIB::sysName.0"], "profile_a,profile_b")
-        mock_logger.debug.assert_called_once_with(
-            "Profile.add_mappings owner=test key=SNMPv2-MIB::sysName.0 "
-            "dict1_profiles=['profile_a', 'profile_b'] "
-            "dict2_profiles=['profile_b', 'profile_a'] "
-            "added_profiles=[] result_profiles=['profile_a', 'profile_b']"
         )

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pysnmp.smi.rfc1902 import ObjectType
 
@@ -219,4 +219,145 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(
             profile3.varbinds_bulk_mapping,
             {"TCP-MIB": "test,test2", "UDP-MIB": "test,test2", "IF-MIB": "test"},
+        )
+
+    def test_add_mappings_does_not_mutate_inputs(self):
+        profile = Profile("test", self.profile_dict)
+        left_mapping = {
+            "SNMPv2-MIB::sysName.0": "profile_a",
+            "SNMPv2-MIB::sysContact.0": "profile_a",
+        }
+        right_mapping = {
+            "SNMPv2-MIB::sysName.0": "profile_b",
+            "SNMPv2-MIB::sysLocation.0": "profile_b",
+        }
+        original_left = left_mapping.copy()
+        original_right = right_mapping.copy()
+
+        result = profile.add_mappings(left_mapping, right_mapping)
+
+        self.assertEqual(left_mapping, original_left)
+        self.assertEqual(right_mapping, original_right)
+        self.assertIsNot(result, left_mapping)
+        self.assertIsNot(result, right_mapping)
+        self.assertEqual(
+            result,
+            {
+                "SNMPv2-MIB::sysName.0": "profile_a,profile_b",
+                "SNMPv2-MIB::sysContact.0": "profile_a",
+                "SNMPv2-MIB::sysLocation.0": "profile_b",
+            },
+        )
+
+    def test_add_mappings_compares_complete_profile_names(self):
+        profile = Profile("test", self.profile_dict)
+
+        result = profile.add_mappings(
+            {"SNMPv2-MIB::sysName.0": "profile_10"},
+            {"SNMPv2-MIB::sysName.0": "profile_1"},
+        )
+
+        self.assertEqual(result["SNMPv2-MIB::sysName.0"], "profile_10,profile_1")
+
+    def test_add_mappings_deduplicates_profiles_in_both_mappings(self):
+        profile = Profile("test", self.profile_dict)
+        mapping_key = "SNMPv2-MIB::sysName.0"
+        cases = [
+            (
+                "profile_a,profile_b,profile_a",
+                "profile_b,profile_a,profile_b",
+                "profile_a,profile_b",
+            ),
+            (
+                "profile_a,profile_b,profile_a",
+                "profile_b,profile_c,profile_a,profile_c",
+                "profile_a,profile_b,profile_c",
+            ),
+        ]
+
+        for dict1_profiles, dict2_profiles, expected_profiles in cases:
+            with self.subTest(
+                dict1_profiles=dict1_profiles,
+                dict2_profiles=dict2_profiles,
+            ):
+                result = profile.add_mappings(
+                    {mapping_key: dict1_profiles},
+                    {mapping_key: dict2_profiles},
+                )
+
+                self.assertEqual(result[mapping_key], expected_profiles)
+
+    def test_repeated_profile_combinations_do_not_grow_cached_mappings(self):
+        profile_body = {
+            "frequency": 10,
+            "varBinds": [
+                ["SNMPv2-MIB", "sysName", 0],
+                ["SNMPv2-MIB", "sysDescr"],
+                ["IF-MIB", "ifDescr"],
+            ],
+        }
+        profile_a = Profile("profile_a", profile_body)
+        profile_b = Profile("profile_b", profile_body)
+        profile_a.process()
+        profile_b.process()
+
+        for _ in range(10):
+            combined_ab = profile_a + profile_b
+            combined_ba = profile_b + profile_a
+
+            self.assertEqual(
+                combined_ab.varbinds_get_mapping["SNMPv2-MIB::sysName.0"],
+                "profile_a,profile_b",
+            )
+            self.assertEqual(
+                combined_ba.varbinds_get_mapping["SNMPv2-MIB::sysName.0"],
+                "profile_b,profile_a",
+            )
+            self.assertEqual(
+                combined_ab.varbinds_bulk_mapping["IF-MIB::ifDescr"],
+                "profile_a,profile_b",
+            )
+            self.assertEqual(
+                combined_ba.varbinds_bulk_mapping["IF-MIB::ifDescr"],
+                "profile_b,profile_a",
+            )
+
+        self.assertEqual(
+            profile_a.varbinds_get_mapping,
+            {"SNMPv2-MIB::sysName.0": "profile_a"},
+        )
+        self.assertEqual(
+            profile_b.varbinds_get_mapping,
+            {"SNMPv2-MIB::sysName.0": "profile_b"},
+        )
+        self.assertEqual(
+            profile_a.varbinds_bulk_mapping,
+            {
+                "SNMPv2-MIB::sysDescr": "profile_a",
+                "IF-MIB::ifDescr": "profile_a",
+            },
+        )
+        self.assertEqual(
+            profile_b.varbinds_bulk_mapping,
+            {
+                "SNMPv2-MIB::sysDescr": "profile_b",
+                "IF-MIB::ifDescr": "profile_b",
+            },
+        )
+
+    @patch("splunk_connect_for_snmp.snmp.varbinds_resolver.logger")
+    def test_add_mappings_logs_duplicate_decision(self, mock_logger):
+        profile = Profile("test", self.profile_dict)
+
+        result = profile.add_mappings(
+            {"SNMPv2-MIB::sysName.0": "profile_a,profile_b"},
+            {"SNMPv2-MIB::sysName.0": "profile_b,profile_a"},
+        )
+
+        self.assertEqual(result["SNMPv2-MIB::sysName.0"], "profile_a,profile_b")
+        mock_logger.debug.assert_called_once_with(
+            "Profile.add_mappings owner=test key=SNMPv2-MIB::sysName.0 "
+            "dict1_profiles=['profile_a', 'profile_b'] "
+            "dict2_profiles=['profile_b', 'profile_a'] "
+            "added_profiles=[] result_profiles=['profile_a', 'profile_b']"
         )

--- a/test/snmp/test_varbinds_resolver.py
+++ b/test/snmp/test_varbinds_resolver.py
@@ -222,23 +222,26 @@ class TestProfile(unittest.TestCase):
 
     def test_add_mappings_does_not_mutate_inputs(self):
         profile = Profile("test", self.profile_dict)
-        left_mapping = {
+        base_mapping = {
             "SNMPv2-MIB::sysName.0": "profile_a",
             "SNMPv2-MIB::sysContact.0": "profile_a",
         }
-        right_mapping = {
+        incoming_mapping = {
             "SNMPv2-MIB::sysName.0": "profile_b",
             "SNMPv2-MIB::sysLocation.0": "profile_b",
         }
-        original_left = left_mapping.copy()
-        original_right = right_mapping.copy()
+        original_base_mapping = base_mapping.copy()
+        original_incoming_mapping = incoming_mapping.copy()
 
-        result = profile.add_mappings(left_mapping, right_mapping)
+        result = profile.add_mappings(
+            base_mapping=base_mapping,
+            incoming_mapping=incoming_mapping,
+        )
 
-        self.assertEqual(left_mapping, original_left)
-        self.assertEqual(right_mapping, original_right)
-        self.assertIsNot(result, left_mapping)
-        self.assertIsNot(result, right_mapping)
+        self.assertEqual(base_mapping, original_base_mapping)
+        self.assertEqual(incoming_mapping, original_incoming_mapping)
+        self.assertIsNot(result, base_mapping)
+        self.assertIsNot(result, incoming_mapping)
         self.assertEqual(
             result,
             {
@@ -252,8 +255,8 @@ class TestProfile(unittest.TestCase):
         profile = Profile("test", self.profile_dict)
 
         result = profile.add_mappings(
-            {"SNMPv2-MIB::sysName.0": "profile_10"},
-            {"SNMPv2-MIB::sysName.0": "profile_1"},
+            base_mapping={"SNMPv2-MIB::sysName.0": "profile_10"},
+            incoming_mapping={"SNMPv2-MIB::sysName.0": "profile_1"},
         )
 
         self.assertEqual(result["SNMPv2-MIB::sysName.0"], "profile_10,profile_1")
@@ -274,14 +277,14 @@ class TestProfile(unittest.TestCase):
             ),
         ]
 
-        for dict1_profiles, dict2_profiles, expected_profiles in cases:
+        for base_profiles, incoming_profiles, expected_profiles in cases:
             with self.subTest(
-                dict1_profiles=dict1_profiles,
-                dict2_profiles=dict2_profiles,
+                base_profiles=base_profiles,
+                incoming_profiles=incoming_profiles,
             ):
                 result = profile.add_mappings(
-                    {mapping_key: dict1_profiles},
-                    {mapping_key: dict2_profiles},
+                    base_mapping={mapping_key: base_profiles},
+                    incoming_mapping={mapping_key: incoming_profiles},
                 )
 
                 self.assertEqual(result[mapping_key], expected_profiles)


### PR DESCRIPTION
# Description

- Fixes unbounded growth of profile labels in `get_mapping` and `bulk_mapping` when multiple profiles containing the same OID are combined repeatedly in different orders.

- The existing merge logic modifies cached profile mappings and compares complete comma-separated strings instead of individual profile names. This can cause duplicate profile labels to grow at exponential rate inside a long-running Celery poller child.


Fixes # (issue)

- Prevent duplicate profiles when merging varbind mappings to avoid mappings growing unnecessarily large

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings