### PR TITLE
feat: added bounded docker container log retention to prevent disk usage growth

### DIFF
--- a/docker_compose/.env
+++ b/docker_compose/.env
@@ -33,6 +33,13 @@ MONGO_TAG=8.3.4
 # Mitigates a MongoDB 8.x SIGSEGV observed on host kernels >= 6.19 (e.g. Ubuntu 26.04).
 MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1
 
+# Docker container log rotation
+# Set the next value to the output from: docker info --format '{{.LoggingDriver}}'
+DOCKER_LOG_DRIVER=json-file
+DOCKER_LOG_MAX_SIZE=10m
+DOCKER_LOG_MAX_FILE=5
+DOCKER_LOG_COMPRESS=true
+
 # Splunk instance configuration
 SPLUNK_HEC_HOST=
 SPLUNK_HEC_PROTOCOL=https

--- a/docker_compose/docker-compose.yaml
+++ b/docker_compose/docker-compose.yaml
@@ -1,3 +1,10 @@
+x-default-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "${DOCKER_LOG_MAX_SIZE:-10m}"
+    max-file: "${DOCKER_LOG_MAX_FILE:-5}"
+    compress: "${DOCKER_LOG_COMPRESS:-true}"
+
 x-general_sc4snmp_data: &general_sc4snmp_data
   CONFIG_PATH: /app/config/config.yaml
   REDIS_URL: redis://redis:6379/1
@@ -82,6 +89,7 @@ networks:
 services:
   coredns:
     image: ${COREDNS_IMAGE}:${COREDNS_TAG:-latest}
+    logging: *default-logging
     command: [-conf, /Corefile]
     container_name: coredns
     restart: on-failure
@@ -97,6 +105,7 @@ services:
   snmp-mibserver:
     <<: [*dns_and_networks, *dependend_on_core_dns]
     image: ${MIBSERVER_IMAGE}:${MIBSERVER_TAG:-latest}
+    logging: *default-logging
     container_name: snmp-mibserver
     environment:
       NGINX_ENTRYPOINT_QUIET_LOGS: ${NGINX_ENTRYPOINT_QUIET_LOGS:-1}
@@ -106,18 +115,21 @@ services:
   redis:
     <<: [*dns_and_networks, *dependend_on_core_dns]
     image: ${REDIS_IMAGE}:${REDIS_TAG:-latest}
+    logging: *default-logging
     container_name: redis
     environment:
       ALLOW_EMPTY_PASSWORD: yes
   mongo:
     <<: [*dns_and_networks, *dependend_on_core_dns]
     image: ${MONGO_IMAGE}:${MONGO_TAG:-latest}
+    logging: *default-logging
     container_name: mongo
     environment:
       GLIBC_TUNABLES: ${MONGO_GLIBC_TUNABLES:-glibc.pthread.rseq=1}
   inventory:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     container_name: sc4snmp-inventory
     command: [inventory]
     environment:
@@ -134,6 +146,7 @@ services:
   scheduler:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     container_name: sc4snmp-scheduler
     command: [celery, beat]
     environment:
@@ -158,6 +171,7 @@ services:
       INCLUDE_SECURITY_CONTEXT_ID: ${INCLUDE_SECURITY_CONTEXT_ID:-false}
       MAX_TRAP_VARBINDS_TO_DECODE: ${MAX_TRAP_VARBINDS_TO_DECODE:-0}
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     ports:
     - mode: host
       protocol: udp
@@ -171,6 +185,7 @@ services:
   discovery:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     container_name: sc4snmp-discovery
     profiles: [discovery]
     command: [discovery]
@@ -188,6 +203,7 @@ services:
   worker-discovery:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     profiles: [discovery]
     command:
     - celery
@@ -223,6 +239,7 @@ services:
   worker-poller:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     command:
     - celery
     - worker-poller
@@ -251,6 +268,7 @@ services:
   worker-sender:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     command: [celery, worker-sender]
     secrets:
     - splunk_hec_token
@@ -281,6 +299,7 @@ services:
   worker-trap:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     command: [celery, worker-trap]
     environment:
       <<: [*general_sc4snmp_data, *splunk_general_setup, *splunk_extended_setup, *workers_general_setup,
@@ -312,6 +331,7 @@ services:
   flower:
     <<: [*dns_and_networks, *dependency_and_restart_policy]
     image: ${SC4SNMP_IMAGE}:${SC4SNMP_TAG:-latest}
+    logging: *default-logging
     command: [celery, flower]
     environment:
       <<: [

--- a/docker_compose/manage_logs.py
+++ b/docker_compose/manage_logs.py
@@ -5,6 +5,11 @@ from typing import Union
 import ruamel.yaml
 
 DOCKER_COMPOSE = "docker-compose.yaml"
+DEFAULT_LOGGING_EXTENSION = "x-default-logging"
+JSON_FILE_LOG_DRIVER = "json-file"
+DOCKER_LOG_MAX_SIZE = "${DOCKER_LOG_MAX_SIZE:-10m}"
+DOCKER_LOG_MAX_FILE = "${DOCKER_LOG_MAX_FILE:-5}"
+DOCKER_LOG_COMPRESS = "${DOCKER_LOG_COMPRESS:-true}"
 
 
 def human_bool(flag: Union[str, bool], default: bool = False) -> bool:
@@ -40,8 +45,17 @@ def read_var_from_env(path_to_compose_files: str) -> dict:
         "SPLUNK_HEC_PORT",
         "SPLUNK_LOG_INDEX",
         "SPLUNK_HEC_INSECURESSL",
+        "DOCKER_LOG_DRIVER",
+        "DOCKER_LOG_MAX_SIZE",
+        "DOCKER_LOG_MAX_FILE",
+        "DOCKER_LOG_COMPRESS",
     ]
-    environment = dict()
+    environment = {
+        "DOCKER_LOG_DRIVER": JSON_FILE_LOG_DRIVER,
+        "DOCKER_LOG_MAX_SIZE": DOCKER_LOG_MAX_SIZE,
+        "DOCKER_LOG_MAX_FILE": DOCKER_LOG_MAX_FILE,
+        "DOCKER_LOG_COMPRESS": DOCKER_LOG_COMPRESS,
+    }
     try:
         with open(path_to_compose_files + "/.env") as env_file:
             for line in env_file.readlines():
@@ -66,9 +80,25 @@ def load_template(environment: dict, service_name: str) -> dict:
             splunk-index: "{environment['SPLUNK_LOG_INDEX']}"
             splunk-insecureskipverify: "{environment['SPLUNK_HEC_INSECURESSL']}"
             splunk-sourcetype: "docker:container:splunk-connect-for-snmp-{service_name}"
+            cache-max-size: "{environment['DOCKER_LOG_MAX_SIZE']}"
+            cache-max-file: "{environment['DOCKER_LOG_MAX_FILE']}"
+            cache-compress: "{environment['DOCKER_LOG_COMPRESS']}"
     """
     template_yaml = yaml.load(template)
     return template_yaml
+
+
+def load_bounded_template() -> dict:
+    return {
+        "logging": {
+            "driver": "json-file",
+            "options": {
+                "max-size": DOCKER_LOG_MAX_SIZE,
+                "max-file": DOCKER_LOG_MAX_FILE,
+                "compress": DOCKER_LOG_COMPRESS,
+            },
+        }
+    }
 
 
 def create_logs(environment, path_to_compose_files):
@@ -93,9 +123,12 @@ def delete_logs(path_to_compose_files):
         with open(os.path.join(path_to_compose_files, DOCKER_COMPOSE)) as file:
             yaml_file = yaml.load(file)
 
+        bounded_logging = yaml_file.get(DEFAULT_LOGGING_EXTENSION)
+        if bounded_logging is None:
+            bounded_logging = load_bounded_template()["logging"]
+
         for service_name in yaml_file["services"].keys():
-            yaml_file["services"][service_name]["logging"]["driver"] = "json-file"
-            yaml_file["services"][service_name]["logging"].pop("options")
+            yaml_file["services"][service_name]["logging"] = bounded_logging
 
         with open(os.path.join(path_to_compose_files, DOCKER_COMPOSE), "w") as file:
             yaml.dump(yaml_file, file)
@@ -103,16 +136,59 @@ def delete_logs(path_to_compose_files):
         print(f"Problem with editing docker-compose.yaml. Error: {e}")
 
 
+def use_docker_default_logging(path_to_compose_files):
+    try:
+        yaml = ruamel.yaml.YAML()
+        with open(os.path.join(path_to_compose_files, DOCKER_COMPOSE)) as file:
+            yaml_file = yaml.load(file)
+
+        for service_name in yaml_file["services"].keys():
+            yaml_file["services"][service_name].pop("logging", None)
+
+        with open(os.path.join(path_to_compose_files, DOCKER_COMPOSE), "w") as file:
+            yaml.dump(yaml_file, file)
+    except Exception as e:
+        print(f"Problem with editing docker-compose.yaml. Error: {e}")
+
+
+def configure_default_logging(environment: dict, path_to_compose_files: str) -> str:
+    logging_driver = (
+        environment.get("DOCKER_LOG_DRIVER", JSON_FILE_LOG_DRIVER).strip()
+        or JSON_FILE_LOG_DRIVER
+    )
+    if logging_driver == JSON_FILE_LOG_DRIVER:
+        delete_logs(path_to_compose_files)
+    else:
+        use_docker_default_logging(path_to_compose_files)
+    return logging_driver
+
+
 def main():
     parser = argparse.ArgumentParser(description="Manage logs in docker compose")
     parser.add_argument(
-        "-e", "--enable_logs", action="store_true", help="Enables the logs"
+        "-e",
+        "--enable_logs",
+        action="store_true",
+        help="Enables Docker-to-Splunk container-log forwarding",
     )
     parser.add_argument(
         "-p", "--path_to_compose", required=True, help="Path to dockerfiles"
     )
     parser.add_argument(
-        "-d", "--disable_logs", action="store_true", help="Disables the logs"
+        "-d",
+        "--disable_logs",
+        action="store_true",
+        help="Disables Docker-to-Splunk forwarding",
+    )
+    parser.add_argument(
+        "--use_docker_default_logging",
+        action="store_true",
+        help="Uses the Docker daemon default logging configuration",
+    )
+    parser.add_argument(
+        "--configure_default_logging",
+        action="store_true",
+        help="Applies bounded logging when DOCKER_LOG_DRIVER is json-file",
     )
 
     args = parser.parse_args()
@@ -121,6 +197,8 @@ def main():
     enable_logs = human_bool(args.enable_logs)
     path_to_compose_files = args.path_to_compose
     disable_logs = human_bool(args.disable_logs)
+    use_docker_default = human_bool(args.use_docker_default_logging)
+    configure_default = human_bool(args.configure_default_logging)
 
     if not os.path.exists(path_to_compose_files):
         print("Path to compose files doesn't exist")
@@ -136,6 +214,17 @@ def main():
     if disable_logs:
         try:
             delete_logs(path_to_compose_files)
+        except ValueError as e:
+            print(e)
+    if use_docker_default:
+        try:
+            use_docker_default_logging(path_to_compose_files)
+        except ValueError as e:
+            print(e)
+    if configure_default:
+        try:
+            logging_driver = configure_default_logging(env, path_to_compose_files)
+            print(f"Configured Docker logging driver: {logging_driver}")
         except ValueError as e:
             print(e)
 

--- a/docs/dockercompose/6-env-file-configuration.md
+++ b/docs/dockercompose/6-env-file-configuration.md
@@ -74,6 +74,21 @@ Once the required variables above are set, you can [Deploy the app](./11-deploy-
 | `MONGO_TAG`       | MongoDB image tag to pull            |
 | `MONGO_GLIBC_TUNABLES` | Value passed as `GLIBC_TUNABLES` to the `mongo` container. Defaults to `glibc.pthread.rseq=1` to mitigate a MongoDB 8.x SIGSEGV observed on host kernels >= 6.19 (e.g. Ubuntu 26.04). Safe no-op on older kernels. See [MongoDB 8.x crash on Linux kernel 6.19+](../troubleshooting/general-issues.md#mongodb-8x-crash-on-linux-kernel-619-exit-139--sigsegv). |
 
+### Docker logging
+
+Docker Compose applies bounded `json-file` logging by default. Existing `json-file` deployments receive rotation when their containers are recreated. To preserve `local`, `journald`, or another Docker daemon driver during an upgrade, set `DOCKER_LOG_DRIVER` before starting the upgraded deployment. See [Docker logging](./7-docker-logging.md) for upgrade, switching, and verification procedures.
+
+The default limits retain up to approximately 50 MB of uncompressed logs per container. Compression normally reduces the disk used by rotated files.
+
+| Variable              | Description                                                     |
+|-----------------------|-----------------------------------------------------------------|
+| `DOCKER_LOG_DRIVER`   | Docker daemon logging driver reported by `docker info --format '{{.LoggingDriver}}'`. `json-file`, an empty value, or a missing value uses bounded `json-file` logging. Another driver name, or `inherit`, preserves daemon inheritance after running `--configure_default_logging`. Default: `json-file` |
+| `DOCKER_LOG_MAX_SIZE` | Maximum size of each container log file. Use a positive size such as `100k`, `10m`, or `1g`. Default: `10m` |
+| `DOCKER_LOG_MAX_FILE` | Maximum number of log files retained per container. Use a positive integer. Default: `5` |
+| `DOCKER_LOG_COMPRESS` | Compress rotated log files. Supported values: `true` or `false`. Default: `true` |
+
+These settings control Docker's local retention when bounded `json-file` logging is selected and the local cache used by Docker-to-Splunk logging. They do not change SC4SNMP log levels, messages, or forwarding.
+
 ### Splunk instance
 
 | Variable                                  | Description                                                                                                                           |
@@ -81,8 +96,8 @@ Once the required variables above are set, you can [Deploy the app](./11-deploy-
 | `SPLUNK_HEC_HOST`                         | IP address or a domain name of a Splunk instance to send data to                                                                      |
 | `SPLUNK_HEC_PROTOCOL`                     | The protocol of the HEC endpoint: `https` or `http`                                                                                   |
 | `SPLUNK_HEC_PORT`                         | The port of the HEC endpoint                                                                                                          |
-| `SPLUNK_HEC_TOKEN`                        | Splunk HTTP Event Collector token. To keep it out of `.env` and `docker inspect`, use a [Docker secret](../configuration/snmpv3.md#splunk-hec-token-secret); the app then reads the token from the file path in `SPLUNK_HEC_TOKEN_FILE`. |
-| `SPLUNK_HEC_TOKEN_SECRET_FILE`            | Path on the host to the file used as the Docker secret for the HEC token (worker-sender only). The app reads the token from the mounted file; only the path is in the container env. |
+| `SPLUNK_HEC_TOKEN`                        | Splunk HTTP Event Collector token. To keep it out of `.env` and `docker inspect`, use a [Docker secret](../configuration/snmpv3.md#splunk-hec-token-secret). The app then reads the token from the file path in `SPLUNK_HEC_TOKEN_FILE`. |
+| `SPLUNK_HEC_TOKEN_SECRET_FILE`            | Path on the host to the file used as the Docker secret for the HEC token (worker-sender only). The app reads the token from the mounted file. Only the path is in the container env. |
 | `SPLUNK_HEC_INSECURESSL`                  | Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS                                             |
 | `SPLUNK_SOURCETYPE_TRAPS`                 | Splunk sourcetype for trap events                                                                                                     |
 | `SPLUNK_SOURCETYPE_POLLING_EVENTS`        | Splunk sourcetype for non-metric polling events                                                                                       |

--- a/docs/dockercompose/7-docker-logging.md
+++ b/docs/dockercompose/7-docker-logging.md
@@ -1,0 +1,106 @@
+# Docker logging
+
+SC4SNMP applications write logs to container standard output and standard error. Docker controls how those container logs are stored and retained. These settings do not change SC4SNMP log levels, messages, formats, or destinations.
+
+The default Compose configuration uses the `json-file` driver with bounded rotation for every service:
+
+```dotenv
+DOCKER_LOG_DRIVER=json-file
+DOCKER_LOG_MAX_SIZE=10m
+DOCKER_LOG_MAX_FILE=5
+DOCKER_LOG_COMPRESS=true
+```
+
+Docker applies logging-driver changes when containers are created. Run `docker compose up -d` after changing the logging configuration so Compose can recreate the affected containers.
+
+## Choose the logging behavior
+
+Check the Docker daemon's current logging driver before a new installation or upgrade:
+
+```shell
+sudo docker info --format '{{.LoggingDriver}}'
+```
+
+| Desired behavior | Value in `.env` | Result after running `--configure_default_logging` |
+|------------------|-----------------|----------------------------------------------------|
+| Use bounded `json-file` logging | `DOCKER_LOG_DRIVER=json-file` | Compose applies `json-file` with the configured rotation limits |
+| Keep the Docker daemon's current driver | Use the value reported by `docker info` | Compose logging is removed and containers inherit the daemon driver |
+| Explicitly inherit the daemon driver | `DOCKER_LOG_DRIVER=inherit` | Compose logging is removed and containers inherit the daemon driver |
+| Use the SC4SNMP default | Leave the variable missing or empty | Compose applies bounded `json-file` logging |
+
+`DOCKER_LOG_DRIVER` is a selector used by `manage_logs.py`. It does not directly set a non-JSON driver on each service. For example, `DOCKER_LOG_DRIVER=local` makes containers use `local` only when `local` is the Docker daemon default.
+
+## Keep the current driver during an upgrade
+
+If `docker info` reports `local`, add or update this line in `.env` file:
+
+```dotenv
+DOCKER_LOG_DRIVER=local
+```
+
+Use the exact value reported by `docker info` when preserving another driver. Before starting the upgraded deployment, run:
+
+```shell
+cd /home/ubuntu/docker_compose
+python3 manage_logs.py \
+  --path_to_compose /home/ubuntu/docker_compose \
+  --configure_default_logging
+sudo docker compose config --quiet
+sudo docker compose up -d
+```
+
+The helper removes service-level logging for non-JSON values, allowing the upgraded containers to continue using the Docker daemon driver. If this step is skipped, new or recreated SC4SNMP containers use bounded `json-file` logging.
+
+## Switch to bounded `json-file`
+
+To switch from any current logging driver to bounded `json-file`, set these values in `.env`:
+
+```dotenv
+DOCKER_LOG_DRIVER=json-file
+DOCKER_LOG_MAX_SIZE=10m
+DOCKER_LOG_MAX_FILE=5
+DOCKER_LOG_COMPRESS=true
+```
+
+Apply the configuration:
+
+```shell
+cd /home/ubuntu/docker_compose
+python3 manage_logs.py \
+  --path_to_compose /home/ubuntu/docker_compose \
+  --configure_default_logging
+sudo docker compose config --quiet
+sudo docker compose up -d
+```
+
+This changes logging only for the SC4SNMP Compose services. It does not change the Docker daemon or unrelated containers. Named MongoDB and Redis volumes are preserved by `docker compose up -d`. Do not use `docker compose down -v` for this change.
+
+## Verify the effective configuration
+
+After the containers are recreated, check their logging drivers and options:
+
+```shell
+for id in $(sudo docker compose ps -q)
+do
+  sudo docker inspect \
+    --format '{{.Name}} driver={{.HostConfig.LogConfig.Type}} options={{json .HostConfig.LogConfig.Config}}' \
+    "$id"
+done
+```
+
+Bounded logging reports `driver=json-file` with `max-size`, `max-file`, and `compress`. When daemon inheritance is selected, each container reports the daemon driver.
+
+## Restore Docker daemon inheritance directly
+
+The following command removes service-level logging without reading `DOCKER_LOG_DRIVER`:
+
+```shell
+python3 manage_logs.py \
+  --path_to_compose /home/ubuntu/docker_compose \
+  --use_docker_default_logging
+sudo docker compose up -d
+```
+
+This also removes the SC4SNMP service-level retention limits. If the daemon uses `json-file` without daemon-level `max-size` and `max-file` options, its container logs do not have a configured size limit. Check `/etc/docker/daemon.json` before selecting daemon inheritance.
+
+To send Docker container logs to Splunk instead, see [Sending logs to Splunk](./9-splunk-logging.md).

--- a/docs/dockercompose/9-splunk-logging.md
+++ b/docs/dockercompose/9-splunk-logging.md
@@ -1,12 +1,13 @@
-# Logging
+# Sending logs to Splunk
 
-The default configuration of docker compose is not sending the logs to Splunk. Container logs can be accessed with command:
+The default Docker Compose configuration does not forward container logs to Splunk. SC4SNMP application logging remains enabled, and container logs can be accessed with:
 ```
 docker logs <container_name/id>
 ```
 
-Creating logs requires updating configuration of several docker compose files. To simplify this process, inside the 
-`docker_compose` package there is a `manage_logs.py` file which will automatically manage logs.
+Enabling Docker-to-Splunk forwarding requires updating the logging configuration of every service. To simplify this process, the `docker_compose` package includes `manage_logs.py`.
+
+Docker applies logging-driver changes only when containers are created. Recreate the affected containers after enabling or disabling forwarding. For Docker log retention and daemon-driver inheritance, see [Docker logging](./7-docker-logging.md).
 
 ## Prerequisites
 
@@ -15,46 +16,50 @@ Running script requires installation of `ruamel.yaml` package for python. It can
 pip3 install ruamel.yaml
 ```
 
-The following parameters have to be configured in `.env` file:
+To enable Docker-to-Splunk forwarding, the following parameters have to be configured in `.env` file:
 `SPLUNK_HEC_TOKEN`, `SPLUNK_HEC_PROTOCOL`, `SPLUNK_HEC_HOST`, `SPLUNK_HEC_PORT`, `SPLUNK_LOG_INDEX`, `SPLUNK_HEC_INSECURESSL`.
 
 More about `.env` configuration can be found in [.env file configuration](./6-env-file-configuration.md).
 
 ## Enabling logging
 
-To enable a logging `manage_logs.py` must be run with the following flags:
+To enable Docker-to-Splunk container-log forwarding, run `manage_logs.py` with:
 
 | Flag                      | Description                                          |
 |---------------------------|------------------------------------------------------| 
-| `-e`, `--enable_logs`     | Flag enabling the logs                               |
+| `-e`, `--enable_logs`     | Enable Docker-to-Splunk container-log forwarding     |
 | `-p`, `--path_to_compose` | Absolute path to directory with docker compose files |
 
 Example of enabling logs:
 ```
-python3 manage_logs.py --path_to_compose /home/ubuntu/docker_compose --enable_logs
+python3 manage_logs.py \
+  --path_to_compose /home/ubuntu/docker_compose \
+  --enable_logs
 ```
 
-The script will add required configuration for logging under services in docker compose files.
+The script sets the Splunk logging driver on every service and keeps `docker logs` available through Docker's bounded local dual-logging cache.
 To apply the changes run the: 
 ```
 sudo docker compose up -d
 ```
 command inside the `docker_compose` directory.
 
-## Disabling the logs
+## Disabling Docker to Splunk logs forwarding
 
-To disable logs `manage_logs.py` must be run with the following flags:
+To disable Docker-to-Splunk forwarding, run `manage_logs.py` with:
 
 | Flag                      | Description                                          |
 |---------------------------|------------------------------------------------------| 
-| `-d`, `--disable_logs`    | Flag disabling the logs                              |
+| `-d`, `--disable_logs`    | Disable Docker-to-Splunk container-log forwarding    |
 | `-p`, `--path_to_compose` | Absolute path to directory with docker compose files |
 
-Running the disable command will replace the `logging.driver` section with default docker driver `json-file`. 
+The script restores the bounded `json-file` driver. It does not disable SC4SNMP application logging or change log levels, messages, formats, or stdout/stderr behavior. To inherit the Docker daemon driver instead, follow the [Docker logging](./7-docker-logging.md#choose-the-logging-behavior) instructions after disabling forwarding.
 
 Example of disabling logs:
 ```
-python3 manage_logs.py --path_to_compose /home/ubuntu/docker_compose --disable_logs
+python3 manage_logs.py \
+  --path_to_compose /home/ubuntu/docker_compose \
+  --disable_logs
 ```
 
 To apply the changes run the:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
               - SNMPv3 secrets: "configuration/snmpv3.md"
               - .env file: "dockercompose/6-env-file-configuration.md"
           - Additional configuration:
+              - Docker logging: "dockercompose/7-docker-logging.md"
               - Offline installation: "dockercompose/8-offline-installation.md"
               - Sending logs to Splunk: "dockercompose/9-splunk-logging.md"
               - Enable IPv6: "dockercompose/10-enable-ipv6.md"
@@ -117,8 +118,3 @@ nav:
       - Polling issues: "troubleshooting/polling-issues.md"
       - Traps issues: "troubleshooting/traps-issues.md"
       - Discovery issues: "troubleshooting/discovery-issues.md"
-
-
-
-
-


### PR DESCRIPTION
# Description

 - Provided configurable options to bound the docker container logs to prevent disk usage growth.
 - Added section to control the docker logging, how to configure the docker logging driver in the docs and environment variable: `DOCKER_LOG_DRIVER`, `DOCKER_LOG_MAX_SIZE`, `DOCKER_LOG_MAX_FILE`, `DOCKER_LOG_COMPRESS`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [x] Refactor/improvement
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings