### PR TITLE
fix: remove pip from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ COPY docker_scripts/manage_secrets.py /app/secrets/
 RUN chown 10001:10001 /app/secrets/
 RUN chown 10001:10001 /tmp
 COPY --from=builder /app/.venv /app/.venv
+RUN python -m pip uninstall --yes pip && \
+    /app/.venv/bin/python -m pip uninstall --yes pip
 COPY entrypoint.sh /app/entrypoint.sh
 COPY construct-connection-strings.sh /app/construct-connection-strings.sh
 RUN chmod +x /app/construct-connection-strings.sh /app/entrypoint.sh


### PR DESCRIPTION
# Description
 
Resolves the python vulnerabilities reported by trivy in the SC4SNMP container image.

GHSA-6v7p-g79w-8964 in msgpack 1.1.2 --> High
[GitHub advisory](https://github.com/msgpack/msgpack-python/security/advisories/GHSA-6v7p-g79w-8964)

CVE-2025-47273 in setuptools 70.3.0 --> High
[NIST advisory](https://nvd.nist.gov/vuln/detail/CVE-2025-47273)

CVE-2026-59890 in setuptools 70.3.0 --> Medium
[NIST advisory](https://nvd.nist.gov/vuln/detail/CVE-2026-59890)

Root cause
------------

these vulns were declared in the third-party CycloneDX SBOM embedded inside pip:
`pip/_vendor/bom.cdx.json`

trivy scanned this `SBOM` and reported its msgpack and setuptools entries under a separate Python target.
The separately installed runtime version of setuptools was already patched, so updating the `SC4SNMP` poetry dependencies would not have resolved these findings.

After the application is fully built, pip is removed from both the system Python installation and the `SC4SNMP` virtual environment

```
RUN python -m pip uninstall --yes pip && \
    /app/.venv/bin/python -m pip uninstall --yes pip
 ```
 
This removes the unnecessary runtime package manager, its vendored components, and the embedded SBOM responsible for the trivy findings


## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings