### PR TITLE
docs: add steps for rotating mongodb password

### DIFF
--- a/docs/microk8s/configuration/mongo-configuration.md
+++ b/docs/microk8s/configuration/mongo-configuration.md
@@ -234,7 +234,7 @@ mongodb:
 To use an existing Kubernetes Secret, first create it:
 
 ```yaml
-kubectl create secret generic prod-mongodb-secret -n <namespace> \
+microk8s kubectl create secret generic prod-mongodb-secret -n <namespace> \
   --from-literal=root-user='admin' \
   --from-literal=root-password='your_secure_password_here'
 ```
@@ -275,7 +275,7 @@ To rotate the password without losing data, perform the steps **in this order**:
 1. **Re-key the running database**, authenticating with the *current* (old) password:
 
     ```bash
-    kubectl exec -it <release>-mongodb-0 -n <namespace> -- mongosh \
+    micrk8s kubectl exec -it <release>-mongodb-0 -n <namespace> -- mongosh \
       -u admin -p '<OLD_PASSWORD>' --authenticationDatabase admin \
       --eval 'db.getSiblingDB("admin").changeUserPassword("admin","<NEW_PASSWORD>")'
     ```
@@ -289,15 +289,15 @@ To rotate the password without losing data, perform the steps **in this order**:
 2. **Update the credential source Helm/pods will use next**, then apply it:
     - Direct password: set the new value in `mongodb.auth.rootPassword` in `values.yaml`.
     - Existing Secret: update the `root-password` key of that Secret (e.g. via
-      `kubectl create secret generic ... --dry-run=client -o yaml | kubectl apply -f -`
-      or `kubectl patch secret`).
+      `microk8s kubectl create secret generic ... --dry-run=client -o yaml | kubectl apply -f -`
+      or `microk8s kubectl patch secret`).
 
     Then run `helm upgrade` so the chart picks up the change.
 
 3. **Restart the application pods** so they re-read the updated credentials:
 
     ```bash
-    kubectl rollout restart statefulset,deployment -n <namespace>
+    microk8s kubectl rollout restart statefulset,deployment -n <namespace>
     ```
 
 !!!danger

--- a/docs/microk8s/configuration/mongo-configuration.md
+++ b/docs/microk8s/configuration/mongo-configuration.md
@@ -28,7 +28,7 @@ mongodb:
     enabled: false
     rootUser: "admin"
     rootPassword: ""                  # Set if auth.enabled: true
-    existingUserSecret: ""            # Or reference existing secret
+    existingSecret: ""                # Or reference existing secret
     rootUserKey: "root-user"
     rootPasswordKey: "root-password"
 
@@ -83,7 +83,7 @@ mongodb:
 | mongodb.auth.enabled                       | bool   | true                                                      | Enable MongoDB authentication.                                   |
 | mongodb.auth.rootUser                      | string | admin                                                     | Root username for MongoDB.                                       |
 | mongodb.auth.rootPassword                  | string | ""                                                        | Root password (avoid committing; prefer secret).                 |
-| mongodb.auth.existingUserSecret            | string | ""                                                        | Name of existing Kubernetes Secret providing credentials.        |
+| mongodb.auth.existingSecret                | string | ""                                                        | Name of existing Kubernetes Secret providing credentials.        |
 | mongodb.auth.rootUserKey                   | string | root-user                                                 | Key inside existing secret containing the username.              |
 | mongodb.auth.rootPasswordKey               | string | root-password                                             | Key inside existing secret containing the password.              |
 | mongodb.image.repository                   | string | mongo                                                     | Container image repository.                                      |
@@ -245,7 +245,7 @@ Then reference it in `values.yaml`:
 mongodb:
   auth:
     enabled: true
-    existingUserSecret: "prod-mongodb-secret"
+    existingSecret: "prod-mongodb-secret"
 ```
 
 The secret keys (`root-user` and `root-password`) are configurable via `rootUserKey` and `rootPasswordKey` if your secret uses different key names:
@@ -254,11 +254,59 @@ The secret keys (`root-user` and `root-password`) are configurable via `rootUser
 mongodb:
   auth:
     enabled: true
-    existingUserSecret: "prod-mongodb-secret-with-different-keys"
+    existingSecret: "prod-mongodb-secret-with-different-keys"
     rootUserKey: "my-username-key"
     rootPasswordKey: "my-password-key"
 ```
 
+### Rotating the MongoDB password
+
+!!!warning
+    The `mongo` container image only applies `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD`
+    the **first time** it starts against an empty data directory. On an already-initialized
+    deployment (an existing PVC), simply changing `mongodb.auth.rootPassword` or the root-password
+    Secret and running `helm upgrade` does **not** change the password stored inside MongoDB. The
+    database keeps the old password while application pods pick up the new one from the Secret,
+    which breaks authentication for every SC4SNMP component (worker, scheduler, traps, inventory,
+    discovery, UI).
+
+To rotate the password without losing data, perform the steps **in this order**:
+
+1. **Re-key the running database**, authenticating with the *current* (old) password:
+
+    ```bash
+    kubectl exec -it <release>-mongodb-0 -n <namespace> -- mongosh \
+      -u admin -p '<OLD_PASSWORD>' --authenticationDatabase admin \
+      --eval 'db.getSiblingDB("admin").changeUserPassword("admin","<NEW_PASSWORD>")'
+    ```
+
+    !!!note
+        In **replication mode**, the password change must be run against the current PRIMARY.
+        Right after initialization this is `<release>-mongodb-0`; if unsure, connect to any pod
+        and run `db.hello().primary` (or `rs.status()`) to find it. The change then replicates
+        to the other members automatically.
+
+2. **Update the credential source Helm/pods will use next**, then apply it:
+    - Direct password: set the new value in `mongodb.auth.rootPassword` in `values.yaml`.
+    - Existing Secret: update the `root-password` key of that Secret (e.g. via
+      `kubectl create secret generic ... --dry-run=client -o yaml | kubectl apply -f -`
+      or `kubectl patch secret`).
+
+    Then run `helm upgrade` so the chart picks up the change.
+
+3. **Restart the application pods** so they re-read the updated credentials:
+
+    ```bash
+    kubectl rollout restart statefulset,deployment -n <namespace>
+    ```
+
+!!!danger
+    Do not update the Secret or `values.yaml` before completing step 1. If the Secret is changed
+    first, MongoDB and the application pods will disagree on the password and every component
+    will fail to authenticate until the database is re-keyed with the old password (see
+    [Troubleshooting: MongoDB authentication fails after changing the root password](../../troubleshooting/general-issues.md#mongodb-authentication-fails-after-changing-the-root-password)).
+
+This procedure applies to kubernetes deployments only.
 
 ### Migration from Bitnami MongoDB
 

--- a/docs/microk8s/upgrade.md
+++ b/docs/microk8s/upgrade.md
@@ -5,6 +5,12 @@ See the following to update SC4SNMP.
 !!! warning     
     Upgrading SC4SNMP from version `1.12.2` to `1.12.3` includes MongoDB upgrade. In case of any issues refer to [this instruction](../troubleshooting/general-issues.md#upgrading-sc4snmp-from-1122-to-1123).
 
+!!! warning
+    Changing `mongodb.auth.rootPassword` (or the root-password Secret) and running `helm upgrade`
+    does **not** change the password stored inside an already-initialized MongoDB database. See
+    [Rotating the MongoDB password](configuration/mongo-configuration.md#rotating-the-mongodb-password)
+    for the correct procedure before upgrading with a changed password.
+
 ## Upgrade to the latest version
 To upgrade SC4SNMP to the latest version, simply run the following command:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,5 +9,7 @@ SNMP is a protocol widely considered to be risky and requires threat mitigation 
 * When possible use SNMPv3 with the most secure mutually supported protocol options. 
 * The default IP of each node should be considered a management interface and should be protected from network
 access by an untrusted device by a hardware or software firewall. When possible the IP allocated for SNMP communication should not be shared by the management interface.
-* Use strong passwords to secure connectivity to both Redis and MongoDB
+* Use strong passwords to secure connectivity to both Redis and MongoDB. When rotating the MongoDB
+  root password on an existing deployment, follow [Rotating the MongoDB password](microk8s/configuration/mongo-configuration.md#rotating-the-mongodb-password) -
+  simply changing the Secret does not re-key an already-initialized database.
 * For better security it is possible to store secrets in external vaults like HashiCorp Vault, AWS Secret Manager, Azure Key Vault etc.

--- a/docs/troubleshooting/general-issues.md
+++ b/docs/troubleshooting/general-issues.md
@@ -85,6 +85,30 @@ If the `mongo-fcv-upgrade-to-6` job fails for any reason, there are two recovery
 
     Replace `<mongodb-pod-id>` with the actual Pod ID of your MongoDB instance.
 
+### MongoDB authentication fails after changing the root password
+
+!!! warning "Microk8s only"
+
+After changing `mongodb.auth.rootPassword` (or the value of an existing root-password
+Secret) and running `helm upgrade`, application pods (worker, scheduler, traps, inventory,
+discovery, UI) start logging MongoDB authentication failures (e.g. `Authentication failed`)
+while the `mongo` pod itself stays healthy.
+
+
+The `mongo` container only applies `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD`
+the first time it starts against an empty data directory. On an existing PVC, changing the
+Secret updates what the application pods send, but MongoDB itself keeps the old password -
+creating a mismatch.
+
+
+Follow [Rotating the MongoDB password](../microk8s/configuration/mongo-configuration.md#rotating-the-mongodb-password)
+to re-key the database with the *old* password before/while updating the Secret and rolling
+application pods. This does not require any data loss.
+
+If the old password has been lost and cannot be recovered, the only remaining option is to
+[reinstall SC4SNMP with PVC deletion](../microk8s/sc4snmp-installation.md#reinstall-splunk-connect-for-snmp),
+which wipes all MongoDB data (inventory, profiles, walk state, etc.).
+
 ### Addressing Metric Naming Conflicts for Splunk Integration
 
 When collecting SNMP metrics using SC4SNMP, metric names often contain hyphens (e.g., IF-MIB) because the default MIB format includes hyphens in Object Identifiers (OIDs) as specified by standard MIB naming conventions. 


### PR DESCRIPTION
# Description

Updating the Secret containing the MongoDB root password does not update the password stored inside an already initialized MongoDB database. This PR is adding the instruction to documentation on how to mitigate this issue and rotate the password propertly.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## How Has This Been Tested?

manually
